### PR TITLE
chore: remove runtime usage of image_url from commands and query services

### DIFF
--- a/src/app/Console/Commands/AlgoliaImportWorldHeritages.php
+++ b/src/app/Console/Commands/AlgoliaImportWorldHeritages.php
@@ -51,7 +51,12 @@ class AlgoliaImportWorldHeritages extends Command
 
         WorldHeritage::query()
             ->with([
-                'countries',
+                'images' => function ($query) {
+                    $query->where('is_primary', true)->select(['world_heritage_site_id', 'url']);
+                },
+                'countries' => function ($query) {
+                    $query->select(['countries.state_party_code', 'countries.name_en', 'countries.name_jp']);
+                },
             ])
             ->select([
                 'world_heritage_sites.id',
@@ -63,7 +68,6 @@ class AlgoliaImportWorldHeritages extends Command
                 'world_heritage_sites.category',
                 'world_heritage_sites.year_inscribed',
                 'world_heritage_sites.is_endangered',
-                'world_heritage_sites.image_url',
             ])
             ->chunkById($chunk, function ($rows) use ($client, $indexName, $dryRun, &$processed) {
                 $objects = [];
@@ -130,7 +134,7 @@ class AlgoliaImportWorldHeritages extends Command
                         'category' => (string) $row->category,
                         'year_inscribed' => $row->year_inscribed !== null ? (int) $row->year_inscribed : null,
                         'is_endangered' => (bool) $row->is_endangered,
-                        'thumbnail_url' => $row->image_url !== null ? (string) $row->image_url : null,
+                        'thumbnail_url' => $row->images->first()?->url,
                         'state_party_codes' => $statePartyCodes,
                         'country_names_jp' => $countryCount > 1 ? $countryNamesJp : [],
                     ];

--- a/src/app/Console/Commands/ImportWorldHeritageSiteFromSplitFile.php
+++ b/src/app/Console/Commands/ImportWorldHeritageSiteFromSplitFile.php
@@ -96,7 +96,6 @@ class ImportWorldHeritageSiteFromSplitFile extends Command
                 'latitude' => $this->toNullableFloat($row['latitude'] ?? null),
                 'longitude' => $this->toNullableFloat($row['longitude'] ?? null),
                 'short_description' => $this->toNullableString($row['short_description'] ?? null),
-                'image_url' => $this->toNullableString($row['image_url'] ?? null),
                 'unesco_site_url' => $this->toNullableString($row['unesco_site_url'] ?? null),
                 'created_at' => $now,
                 'updated_at' => $now,

--- a/src/app/Packages/Domains/WorldHeritageReadQueryService.php
+++ b/src/app/Packages/Domains/WorldHeritageReadQueryService.php
@@ -33,12 +33,14 @@ class WorldHeritageReadQueryService implements WorldHeritageReadQueryServiceInte
                 'world_heritage_sites.latitude',
                 'world_heritage_sites.longitude',
                 'world_heritage_sites.short_description',
-                'world_heritage_sites.image_url',
             ])
             ->with([
                 'countries' => function ($q) {
                     $q->select('countries.state_party_code', 'countries.name_en', 'countries.name_jp', 'countries.region')
                         ->orderBy('countries.state_party_code', 'asc');
+                },
+                'images' => function ($imageQuery) {
+                    $imageQuery->where('is_primary', true)->limit(1);
                 },
             ])
             ->whereIn('world_heritage_sites.id', $ids)


### PR DESCRIPTION
## What
- AlgoliaImportWorldHeritages: replace image_url select with images eager load, fix countries relation
- WorldHeritageReadQueryService: remove image_url select, add images eager load
- ImportWorldHeritageSiteFromSplitFile: remove image_url from upsert payload

## Why
Removes all runtime references to world_heritage_sites.image_url
in preparation for dropping the column (#300-3).
Images are now sourced exclusively from world_heritage_site_images.