### PR TITLE
chore: drop image_url column from world_heritage_sites

### DIFF
--- a/src/database/migrations/2026_03_29_151147_drop_image_url_from_world_heritage_sites.php
+++ b/src/database/migrations/2026_03_29_151147_drop_image_url_from_world_heritage_sites.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('world_heritage_sites', function (Blueprint $table) {
+            $table->dropColumn('image_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('world_heritage_sites', function (Blueprint $table) {
+            $table->string('image_url')->nullable()->after('short_description');
+        });
+    }
+};


### PR DESCRIPTION
## What
- Add migration to drop `image_url` column from `world_heritage_sites` table

## Why
`image_url` is now sourced exclusively from world_heritage_site_images.
This is the final step of the image refactoring (#294).

## Verification
- Ran `php artisan app:world-heritage-build --fresh --jp --pretty --clear --algolia --algolia-truncate` successfully
- All 1248 records processed without errors