### PR TITLE
perf: add index on site_state_parties.world_heritage_site_id

### DIFF
--- a/src/database/migrations/2026_05_22_000001_add_index_to_site_state_parties_world_heritage_site_id.php
+++ b/src/database/migrations/2026_05_22_000001_add_index_to_site_state_parties_world_heritage_site_id.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('site_state_parties', function (Blueprint $table) {
+            $table->index('world_heritage_site_id', 'idx_ssp_world_heritage_site_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('site_state_parties', function (Blueprint $table) {
+            $table->dropIndex('idx_ssp_world_heritage_site_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

The composite PK on `site_state_parties` is `(state_party_code, world_heritage_site_id)`. When Eloquent eager-loads the `countries` relation for a list page, it runs:

```sql
WHERE site_state_parties.world_heritage_site_id IN (1, 2, 3, ... 30)
```

MySQL cannot use the composite PK for this query (second column only), resulting in a **full table scan** on every list and search request.

This PR adds a single-column index on `world_heritage_site_id`, turning that scan into an index seek.

## Changes

- `2026_05_22_000001_add_index_to_site_state_parties_world_heritage_site_id.php` — adds `idx_ssp_world_heritage_site_id`

## How to verify

```sql
EXPLAIN SELECT countries.*, site_state_parties.world_heritage_site_id
FROM countries
JOIN site_state_parties ON countries.state_party_code = site_state_parties.state_party_code
WHERE site_state_parties.world_heritage_site_id IN (1,2,3);
```

Before: `type: ALL` (full scan)
After: `type: ref`, `key: idx_ssp_world_heritage_site_id`

Closes #464
Part of #463