### PR TITLE
feat: add proxy image route to api.php

### DIFF
--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,10 +2,12 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Packages\Features\Controller\WorldHeritageController;
+use App\Packages\Features\Controller\HeritageImageController;
 
 Route::prefix('v1')->group(function (): void {
     Route::get('/heritages', [WorldHeritageController::class, 'getWorldHeritages']);
     Route::get('/heritages/search', [WorldHeritageController::class, 'searchWorldHeritages']);
     Route::get('heritages/region-count', [WorldHeritageController::class, 'getWorldHeritagesCountByRegion']);
     Route::get('/heritages/{id}', [WorldHeritageController::class, 'getWorldHeritageById']);
+    Route::get('/heritage-image/{id}', [HeritageImageController::class, 'proxyImage']);
 });


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/heritage-image/{id}` route to `routes/api.php`
- Dispatches to `HeritageImageController@proxyImage` (to be implemented in #471)

## Closes

#470

## Part of

#475

## Notes

`HeritageImageController` does not exist yet — it will be created in a follow-up PR (#471). This PR only wires up the route so routing and controller work can be reviewed independently.