### PR TITLE
fix(世界遺産の詳細API): APIのレスポンスに不具合があった為、その修正対応

### DIFF
--- a/src/app/Packages/Domains/Test/QueryService/WorldHeritageQueryService_getByIdTest.php
+++ b/src/app/Packages/Domains/Test/QueryService/WorldHeritageQueryService_getByIdTest.php
@@ -199,4 +199,15 @@ class WorldHeritageQueryService_getByIdTest extends TestCase
         $this->assertIsArray($result->getImages());
         $this->assertEmpty($result->getImages());
     }
+
+    public function test_short_description_jp_is_null_when_no_description(): void
+    {
+        DB::table('world_heritage_descriptions')
+            ->where('world_heritage_site_id', 1133)
+            ->delete();
+
+        $result = $this->queryService->getHeritageById(1133);
+
+        $this->assertNull($result->getShortDescriptionJp());
+    }
 }

--- a/src/app/Packages/Domains/WorldHeritageQueryService.php
+++ b/src/app/Packages/Domains/WorldHeritageQueryService.php
@@ -197,7 +197,7 @@ class WorldHeritageQueryService implements WorldHeritageQueryServiceInterface
             'state_party_code' => $statePartyCodes,
             'state_party_codes' => $statePartyCodesCompat,
             'state_parties_meta' => $statePartiesMeta,
-            'short_description_jp' => $heritage->descriptions->short_description_ja,
+            'short_description_jp' => $heritage->descriptions?->short_description_ja,
             'images' => $imageCollection->toArray(),
             'main_image_url' => $heritage->main_image_url,
         ]);


### PR DESCRIPTION
## 内容
  
### 不具合の原因
`/v1/heritages/{id}(例: id 662)`のAPIで、対応する`world_heritage_descriptions`のレコードが存在しない場合、500エラーが発生していた。
理由は、short_description_ja` カラムが`null`であっても、null-safe演算子を使用せずに、参照するようにしていたため。

### やったこと
- 単一の遺産のデータを取得するQueryService内の`getHeritageById()`で使用されている`$heritage->descriptions->short_description_ja` を`$heritage->descriptions?->short_description_ja` に修正

- テスト追加
  world_heritage_sitesテーブルにあるdescriptionのレコードが存在しない場合、`short_description_jp` が null を返すようにするテスト