### PR TITLE
fix: resolve country_name_jp from the same primary country as country

### DIFF
--- a/src/app/Packages/Domains/Test/QueryService/WorldHeritageQueryService_getByIdTest.php
+++ b/src/app/Packages/Domains/Test/QueryService/WorldHeritageQueryService_getByIdTest.php
@@ -63,6 +63,7 @@ class WorldHeritageQueryService_getByIdTest extends TestCase
             'name' => "Ancient and Primeval Beech Forests",
             'heritage_name_jp' => "カルパティア山脈とヨーロッパ各地の古代及び原生ブナ林",
             'country' => 'Slovakia',
+            'country_name_jp' => 'スロバキア',
             'study_region' => 'Europe',
             'category' => 'Natural',
             'criteria' => ['ix'],
@@ -149,6 +150,7 @@ class WorldHeritageQueryService_getByIdTest extends TestCase
         $this->assertEquals($this->arrayData()['name'], $result->getName());
         $this->assertEquals($this->arrayData()['heritage_name_jp'], $result->getHeritageNameJp());
         $this->assertEquals($this->arrayData()['country'], $result->getCountry());
+        $this->assertEquals($this->arrayData()['country_name_jp'], $result->getCountryNameJp());
         $this->assertEquals($this->arrayData()['study_region'], $result->getRegion());
         $this->assertEquals($this->arrayData()['category'], $result->getCategory());
         $this->assertEquals($this->arrayData()['criteria'], $result->getCriteria());

--- a/src/app/Packages/Domains/WorldHeritageQueryService.php
+++ b/src/app/Packages/Domains/WorldHeritageQueryService.php
@@ -163,17 +163,20 @@ class WorldHeritageQueryService implements WorldHeritageQueryServiceInterface
         $statePartyCodesCompat = $codes->all();
 
         $displayCountry = null;
+        $countryNameJp = null;
         if ($codes->count() === 1) {
-            $displayCountry = $heritage->countries->first()?->name_en;
+            $singleCountry = $heritage->countries->first();
+            $displayCountry = $singleCountry?->name_en;
+            $countryNameJp = $singleCountry?->name_jp;
         } elseif ($codes->count() > 1) {
-            $primary = $heritage->countries->first(
-                static fn ($c) => (bool) data_get($c, 'pivot.is_primary', false),
+            $primaryCountry = $heritage->countries->first(
+                static fn ($country) => (bool) data_get($country, 'pivot.is_primary', false),
             );
-            $displayCountry = $primary?->name_en;
+            $displayCountry = $primaryCountry?->name_en;
+            $countryNameJp = $primaryCountry?->name_jp;
         }
 
         $displayCountry ??= $heritage->country;
-        $countryNameJp = $heritage->countries->first()?->name_jp;
 
         return WorldHeritageDetailFactory::build([
             'id' => $heritage->id,


### PR DESCRIPTION
## Summary
- For heritage sites with multiple state parties, `country` (English) and `country_name_jp` (Japanese) were resolved from two different code paths in `WorldHeritageQueryService::getHeritageById()`, so they could disagree.
- `country` correctly looked up the country flagged `is_primary`. `country_name_jp` instead just took `$heritage->countries->first()?->name_jp`, and since the `countries` relation is ordered alphabetically by `state_party_code`, it returned whichever country sorts first — not necessarily the primary one.
- Example: id 1321 ("The Architectural Work of Le Corbusier..."), primary state party is `IND` (India), but `country_name_jp` returned `"アルゼンチン"` (Argentina, which sorts first alphabetically) instead of `"インド"`.

## Changes
- `WorldHeritageQueryService::getHeritageById()`: resolve `country` and `country_name_jp` from the same primary-country lookup instead of two separate code paths.
- Added a regression assertion in `WorldHeritageQueryService_getByIdTest::test_check_data_value` covering `country_name_jp` against the existing multi-country fixture (id 1133, where `SVK` is primary but `ALB` sorts first alphabetically).

## Test plan
- [x] Confirmed the new assertion fails against the pre-fix code (`country_name_jp` returns `'アルバニア'` instead of the expected `'スロバキア'`).
- [x] Confirmed the full test suite (77 tests) passes after the fix.

Closes #483