### PR TITLE
feat: add parser for UNESCO components_list raw field

### DIFF
--- a/src/app/Packages/Domains/Test/WorldHeritageComponentsListParserTest.php
+++ b/src/app/Packages/Domains/Test/WorldHeritageComponentsListParserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Packages\Domains\Test;
+
+use App\Packages\Domains\WorldHeritageComponentsListParser;
+use Tests\TestCase;
+
+class WorldHeritageComponentsListParserTest extends TestCase
+{
+    public function test_parses_multiple_components(): void
+    {
+        $rawComponentsList = '{name: Complexe du Capitole, ref: 1321rev-014, latitude: 30.7575, longitude: 76.8055555556}, '
+            . '{name: Maison du docteur Curutchet, ref: 1321rev-011, latitude: -34.9113416667, longitude: -57.941825}';
+
+        $components = WorldHeritageComponentsListParser::parse($rawComponentsList);
+
+        $this->assertCount(2, $components);
+
+        $this->assertSame('Complexe du Capitole', $components[0]['name']);
+        $this->assertSame('1321rev-014', $components[0]['ref']);
+        $this->assertSame(30.7575, $components[0]['latitude']);
+        $this->assertSame(76.8055555556, $components[0]['longitude']);
+
+        $this->assertSame('Maison du docteur Curutchet', $components[1]['name']);
+        $this->assertSame('1321rev-011', $components[1]['ref']);
+        $this->assertSame(-34.9113416667, $components[1]['latitude']);
+        $this->assertSame(-57.941825, $components[1]['longitude']);
+    }
+
+    public function test_handles_name_with_trailing_space_before_comma(): void
+    {
+        $rawComponentsList = '{name: Museum-City of Gjirokastra , ref: 569-001, latitude: 40.0741666667, longitude: 20.1408333333}';
+
+        $components = WorldHeritageComponentsListParser::parse($rawComponentsList);
+
+        $this->assertCount(1, $components);
+        $this->assertSame('Museum-City of Gjirokastra', $components[0]['name']);
+    }
+
+    public function test_returns_empty_array_for_null_or_blank_input(): void
+    {
+        $this->assertSame([], WorldHeritageComponentsListParser::parse(null));
+        $this->assertSame([], WorldHeritageComponentsListParser::parse(''));
+        $this->assertSame([], WorldHeritageComponentsListParser::parse('   '));
+    }
+
+    public function test_skips_malformed_blocks(): void
+    {
+        $rawComponentsList = '{name: Missing Coordinates, ref: 999-001}, '
+            . '{name: Valid Component, ref: 999-002, latitude: 1.5, longitude: 2.5}';
+
+        $components = WorldHeritageComponentsListParser::parse($rawComponentsList);
+
+        $this->assertCount(1, $components);
+        $this->assertSame('Valid Component', $components[0]['name']);
+    }
+}

--- a/src/app/Packages/Domains/WorldHeritageComponentsListParser.php
+++ b/src/app/Packages/Domains/WorldHeritageComponentsListParser.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Packages\Domains;
+
+/**
+ * Parses UNESCO's `components_list` raw field, e.g.
+ * "{name: Cité Frugès, ref: 1321rev-003, latitude: 44.79, longitude: -0.64}, {name: ..., ...}"
+ * into a list of structured sub-site rows (one per physical component of a
+ * serial/transnational property).
+ */
+class WorldHeritageComponentsListParser
+{
+    public static function parse(mixed $rawComponentsList): array
+    {
+        if (!is_string($rawComponentsList) || trim($rawComponentsList) === '') {
+            return [];
+        }
+
+        if (!preg_match_all('/\{(.*?)\}/s', $rawComponentsList, $blockMatches)) {
+            return [];
+        }
+
+        $components = [];
+        foreach ($blockMatches[1] as $block) {
+            $component = self::parseBlock($block);
+            if ($component !== null) {
+                $components[] = $component;
+            }
+        }
+
+        return $components;
+    }
+
+    private static function parseBlock(string $block): ?array
+    {
+        $pattern = '/name:\s*(.*?),\s*ref:\s*(.*?),\s*latitude:\s*([\-0-9.]+),\s*longitude:\s*([\-0-9.]+)/s';
+        if (!preg_match($pattern, $block, $fieldMatches)) {
+            return null;
+        }
+
+        $name = trim($fieldMatches[1]);
+        $ref = trim($fieldMatches[2]);
+        $latitude = $fieldMatches[3];
+        $longitude = $fieldMatches[4];
+
+        if ($name === '' || !is_numeric($latitude) || !is_numeric($longitude)) {
+            return null;
+        }
+
+        return [
+            'name' => $name,
+            'ref' => $ref !== '' ? $ref : null,
+            'latitude' => (float) $latitude,
+            'longitude' => (float) $longitude,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- Serial/transnational heritage properties (one property spread across multiple countries) list their physical sub-sites in UNESCO's raw `components_list` field, formatted as a loose, non-JSON string: `"{name: ..., ref: ..., latitude: ..., longitude: ...}, {...}"`.
- This data is currently discarded during import. It's the building block for fixing #482 (thumbnail image and map pin can represent different countries) — once persisted, per-sub-site coordinates can be used to keep the displayed thumbnail and map pin consistent for multi-country properties.
- This PR only adds the parser + tests. It is **not yet wired into the import pipeline** — that's a separate follow-up once the storage approach is decided.

## Changes
- `WorldHeritageComponentsListParser::parse()`: extracts `{name, ref, latitude, longitude}` blocks from the raw string, skipping malformed entries (e.g. missing coordinates).
- Tests cover: multiple components, names with a trailing space before the comma, null/blank input, and malformed blocks being skipped.

## Test plan
- [x] `php artisan test --filter=WorldHeritageComponentsListParserTest` — 4 passed.

Relates to #482.