### PR TITLE
fix:  `app:world-heritage-build --fresh` failing silently in production.

### DIFF
--- a/src/app/Console/Commands/WorldHeritageBuild.php
+++ b/src/app/Console/Commands/WorldHeritageBuild.php
@@ -56,7 +56,7 @@ class WorldHeritageBuild extends Command
         }
 
         if ((bool) $this->option('fresh')) {
-            $this->callOrFail('migrate:fresh');
+            $this->callOrFail('migrate:fresh', ['--force' => true]);
         }
 
         $pretty = (bool) $this->option('pretty');


### PR DESCRIPTION
## Summary

### Problem
When running `app:world-heritage-build` with the `--fresh` flag, the command internally calls `migrate:fresh` without passing `--force`:

```php
if ((bool) $this->option('fresh')) {
    $this->callOrFail('migrate:fresh');
}
```

### What I have done

Pass `--force` explicitly when calling `migrate:fresh`, consistent with how other sub-commands in the same file (e.g. `translate-short-description-japanese`) already forward `--force`:

```php
if ((bool) $this->option('fresh')) {
    $this->callOrFail('migrate:fresh', ['--force' => true]);
}
```