### PR TITLE
feat: usersテーブルのmigrationとUserモデルの追加 / Add users table migration and User model

### DIFF
--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    protected $table = 'users';
+
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'email',
+        'password',
+        'age_range',
+        'subscription_tier',
+        'subscription_expires_at',
+        'email_verified_at',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'password'                => 'hashed',
+            'subscription_expires_at' => 'datetime',
+            'email_verified_at'       => 'datetime',
+        ];
+    }
+}

--- a/src/database/migrations/2026_06_27_000000_create_users_table.php
+++ b/src/database/migrations/2026_06_27_000000_create_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('age_range', ['teens', '20s', '30s', '40s', '50s', '60plus']);
+            $table->enum('subscription_tier', ['free', 'premium'])->default('free');
+            $table->timestamp('subscription_expires_at')->nullable();
+            $table->timestamp('email_verified_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};


### PR DESCRIPTION
## 概要 / Summary

- `users` テーブルを作成するmigrationを追加
- `User` Eloquentモデルを追加

## 変更内容 / Changes

### Migration
- `users` テーブルを新規作成
- カラム: `id`, `first_name`, `last_name`, `email`(unique), `password`, `age_range`(enum), `subscription_tier`(enum), `subscription_expires_at`, `email_verified_at`, `timestamps`
- `age_range` はマーケティング用途のユーザー年齢層（`teens` / `20s` / `30s` / `40s` / `50s` / `60plus`）
- `subscription_tier` は課金ステータス（`free` / `premium`）、デフォルト `free`

### User Model
- `password` は `hashed` キャストにより自動ハッシュ化
- `password` は `$hidden` に設定しレスポンスから除外