### PR TITLE
feat: add User registration application layer

### DIFF
--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -2,12 +2,10 @@
 
 namespace App\Packages\Domains\Interface;
 
-use App\Packages\Domains\User\UserEntity;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 
 interface UserRepositroyInterface
 {
-    public function createUser(
-        UserEntity $entity
-    ): UserDto;
+    public function createUser(CreateUserCommand $command): UserDto;
 }

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -2,10 +2,11 @@
 
 namespace App\Packages\Domains;
 
-use App\Packages\Domains\Interface\UserRepositroyInterface;
 use App\Models\User;
-use App\Packages\Domains\User\UserEntity;
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use App\Packages\Features\QueryUseCases\Factory\Dto\UserDtoFactory;
 use Exception;
 
 class UserRepository implements UserRepositroyInterface
@@ -14,24 +15,21 @@ class UserRepository implements UserRepositroyInterface
         private User $userModel
     ) {}
 
-    public function createUser(
-        UserEntity $entity
-    ): UserDto
+    public function createUser(CreateUserCommand $command): UserDto
     {
         $insertUser = $this->userModel->create([
-            'email'                   => $entity->getEmail(),
-            'first_name'              => $entity->getFirstName(),
-            'last_name'               => $entity->getLastName(),
-            'age_range'               => $entity->getAgeRange()->value,
-            'subscription_tier'       => $entity->getSubscription()->getTier()->value,
-            'subscription_expires_at' => $entity->getSubscription()->getExpiresAt(),
+            'email'                   => $command->email,
+            'first_name'              => $command->firstName,
+            'last_name'               => $command->lastName,
+            'age_range'               => $command->ageRange,
+            'subscription_tier'       => $command->subscriptionTier,
+            'subscription_expires_at' => $command->subscriptionExpiresAt,
         ]);
 
         if (!$insertUser->wasRecentlyCreated) {
             throw new Exception('Failed to create user.');
         }
 
-        return new UserDto();
-
+        return UserDtoFactory::build($insertUser->toArray());
     }
 }

--- a/src/app/Packages/Features/CommandUseCases/UseCase/User/CreateUserUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/User/CreateUserUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCase\User;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+
+final class CreateUserUseCase
+{
+    public function __construct(
+        private readonly UserRepositroyInterface $userRepository,
+    ) {}
+
+    public function handle(CreateUserCommand $command): UserDto
+    {
+        return $this->userRepository->createUser($command);
+    }
+}

--- a/src/app/Packages/Features/CommandUseCases/UseCommand/User/CreateUserCommand.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCommand/User/CreateUserCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCommand\User;
+
+use InvalidArgumentException;
+
+final class CreateUserCommand
+{
+    private const REQUIRED_KEYS = [
+        'first_name',
+        'last_name',
+        'email',
+        'age_range',
+        'subscription_tier',
+    ];
+
+    private function __construct(
+        public readonly string  $firstName,
+        public readonly string  $lastName,
+        public readonly string  $email,
+        public readonly string  $ageRange,
+        public readonly string  $subscriptionTier,
+        public readonly ?string $subscriptionExpiresAt,
+    )
+    {
+    }
+
+    public static function fromArray(array $data): self
+    {
+        foreach (self::REQUIRED_KEYS as $key) {
+            if (!array_key_exists($key, $data)) {
+                throw new InvalidArgumentException("Missing required key: {$key}");
+            }
+        }
+
+        return new self(
+            firstName: $data['first_name'],
+            lastName: $data['last_name'],
+            email: $data['email'],
+            ageRange: $data['age_range'],
+            subscriptionTier: $data['subscription_tier'],
+            subscriptionExpiresAt: $data['subscription_expires_at'] ?? null,
+        );
+    }
+}

--- a/src/app/Packages/Features/QueryUseCases/Dto/User/UserDto.php
+++ b/src/app/Packages/Features/QueryUseCases/Dto/User/UserDto.php
@@ -2,7 +2,15 @@
 
 namespace App\Packages\Features\QueryUseCases\Dto\User;
 
-class UserDto
+final class UserDto
 {
-
+    public function __construct(
+        public readonly int     $id,
+        public readonly string  $firstName,
+        public readonly string  $lastName,
+        public readonly string  $email,
+        public readonly string  $ageRange,
+        public readonly string  $subscriptionTier,
+        public readonly ?string $subscriptionExpiresAt,
+    ) {}
 }

--- a/src/app/Packages/Features/QueryUseCases/Factory/Dto/UserDtoFactory.php
+++ b/src/app/Packages/Features/QueryUseCases/Factory/Dto/UserDtoFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Packages\Features\QueryUseCases\Factory\Dto;
+
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+
+class UserDtoFactory
+{
+    public static function build(array $data): UserDto
+    {
+        return new UserDto(
+            id: (int)$data['id'],
+            firstName: (string)$data['first_name'],
+            lastName: (string)$data['last_name'],
+            email: (string)$data['email'],
+            ageRange: (string)$data['age_range'],
+            subscriptionTier: (string)$data['subscription_tier'],
+            subscriptionExpiresAt: $data['subscription_expires_at'] ?? null,
+        );
+    }
+}

--- a/src/tests/Unit/Packages/Domains/UserRepositoryTest.php
+++ b/src/tests/Unit/Packages/Domains/UserRepositoryTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Packages\Domains;
 
 use App\Models\User;
-use App\Packages\Domains\User\Factory\UserEntityFactory;
 use App\Packages\Domains\UserRepository;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 use Exception;
 use Faker\Factory as FakerFactory;
@@ -19,12 +19,11 @@ class UserRepositoryTest extends TestCase
         Mockery::close();
     }
 
-    private function buildUserEntity(): \App\Packages\Domains\User\UserEntity
+    private function buildCommand(): CreateUserCommand
     {
         $faker = FakerFactory::create();
 
-        return UserEntityFactory::build([
-            'id'                      => $faker->unique()->randomNumber(5),
+        return CreateUserCommand::fromArray([
             'first_name'              => $faker->firstName(),
             'last_name'               => $faker->lastName(),
             'email'                   => $faker->unique()->safeEmail(),
@@ -36,9 +35,22 @@ class UserRepositoryTest extends TestCase
 
     private function buildUserModelMock(bool $wasRecentlyCreated): User
     {
+        $faker = FakerFactory::create();
+
+        $attributes = [
+            'id'                      => $faker->unique()->randomNumber(5),
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ];
+
         /** @var User|MockInterface $createdUser */
         $createdUser = Mockery::mock(User::class);
         $createdUser->wasRecentlyCreated = $wasRecentlyCreated;
+        $createdUser->shouldReceive('toArray')->andReturn($attributes);
 
         /** @var User|MockInterface $userModel */
         $userModel = Mockery::mock(User::class);
@@ -50,7 +62,7 @@ class UserRepositoryTest extends TestCase
     public function test_createUser_returns_user_dto_on_success(): void
     {
         $repository = new UserRepository($this->buildUserModelMock(wasRecentlyCreated: true));
-        $result = $repository->createUser($this->buildUserEntity());
+        $result = $repository->createUser($this->buildCommand());
 
         $this->assertInstanceOf(UserDto::class, $result);
     }
@@ -62,6 +74,6 @@ class UserRepositoryTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to create user.');
 
-        $repository->createUser($this->buildUserEntity());
+        $repository->createUser($this->buildCommand());
     }
 }


### PR DESCRIPTION
## Motivation

With the infrastructure layer in place, the application layer is needed to orchestrate user creation. This PR introduces the command/use-case structure that sits between the presentation layer and the repository, providing input validation and a clear entry point for the create-user flow.

## What I have done

- Added `CreateUserCommand` — validates that all required keys (`first_name`, `last_name`, `email`, `age_range`, `subscription_tier`) are present in the incoming array; exposes data via public readonly properties
- Added `CreateUserUseCase` — receives a `CreateUserCommand` and delegates to `UserRepositoryInterface`, returning a `UserDto`
- Added `UserDtoFactory` — follows the existing factory pattern under `QueryUseCases/Factory/Dto/`; builds a `UserDto` from a raw attribute array
- Updated `UserDto` — replaced the empty stub with typed public readonly properties
- Updated `UserRepositoryInterface` and `UserRepository` — changed the signature from `UserEntity` to `CreateUserCommand`; the repository now converts the command to DB columns directly and uses `UserDtoFactory` to build the return value
- Updated `UserRepositoryTest` — aligned with the new `CreateUserCommand`-based signature; mocks `toArray()` on the inserted model to feed `UserDtoFactory`

## Test Results

```
PASS  Tests\Unit\Packages\Domains\UserRepositoryTest
✓ create user returns user dto on success
✓ create user throws exception when insert fails

Tests: 2 passed (3 assertions)
```