### PR TITLE
feat: add User registration presentation layer / ユーザー登録プレゼンテーション層の追加

### DIFF
--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -21,6 +21,7 @@ class UserRepository implements UserRepositroyInterface
             'email'                   => $command->email,
             'first_name'              => $command->firstName,
             'last_name'               => $command->lastName,
+            'password'                => bcrypt($command->password),
             'age_range'               => $command->ageRange,
             'subscription_tier'       => $command->subscriptionTier,
             'subscription_expires_at' => $command->subscriptionExpiresAt,

--- a/src/app/Packages/Features/CommandUseCases/Factory/ViewModel/UserViewModelFactory.php
+++ b/src/app/Packages/Features/CommandUseCases/Factory/ViewModel/UserViewModelFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\Factory\ViewModel;
+
+use App\Packages\Features\CommandUseCases\ViewModel\User\UserViewModel;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+
+class UserViewModelFactory
+{
+    public static function build(UserDto $dto): UserViewModel
+    {
+        return new UserViewModel($dto);
+    }
+}

--- a/src/app/Packages/Features/CommandUseCases/UseCommand/User/CreateUserCommand.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCommand/User/CreateUserCommand.php
@@ -10,6 +10,7 @@ final class CreateUserCommand
         'first_name',
         'last_name',
         'email',
+        'password',
         'age_range',
         'subscription_tier',
     ];
@@ -18,6 +19,7 @@ final class CreateUserCommand
         public readonly string  $firstName,
         public readonly string  $lastName,
         public readonly string  $email,
+        public readonly string  $password,
         public readonly string  $ageRange,
         public readonly string  $subscriptionTier,
         public readonly ?string $subscriptionExpiresAt,
@@ -37,6 +39,7 @@ final class CreateUserCommand
             firstName: $data['first_name'],
             lastName: $data['last_name'],
             email: $data['email'],
+            password: $data['password'],
             ageRange: $data['age_range'],
             subscriptionTier: $data['subscription_tier'],
             subscriptionExpiresAt: $data['subscription_expires_at'] ?? null,

--- a/src/app/Packages/Features/CommandUseCases/ViewModel/User/UserViewModel.php
+++ b/src/app/Packages/Features/CommandUseCases/ViewModel/User/UserViewModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\ViewModel\User;
+
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+
+final class UserViewModel
+{
+    public function __construct(
+        private readonly UserDto $dto,
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'id'                      => $this->dto->id,
+            'first_name'              => $this->dto->firstName,
+            'last_name'               => $this->dto->lastName,
+            'email'                   => $this->dto->email,
+            'age_range'               => $this->dto->ageRange,
+            'subscription_tier'       => $this->dto->subscriptionTier,
+            'subscription_expires_at' => $this->dto->subscriptionExpiresAt,
+        ];
+    }
+}

--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Packages\Features\Controller;
+
+use App\Http\Controllers\Controller;
+use App\Packages\Features\CommandUseCases\Factory\ViewModel\UserViewModelFactory;
+use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class UserController extends Controller
+{
+    public function createUser(
+        Request $request,
+        CreateUserUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $command  = CreateUserCommand::fromArray($request->all());
+            $dto      = $useCase->handle($command);
+
+            return response()->json([
+                'status' => 'success',
+                'data'   => UserViewModelFactory::build($dto)->toArray(),
+            ], 201);
+        } catch (\Throwable $throwable) {
+            Log::error('Failed to create user', [
+                'message' => $throwable->getMessage(),
+                'trace'   => $throwable->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+}

--- a/src/app/Packages/Features/Tests/CreateUserTest.php
+++ b/src/app/Packages/Features/Tests/CreateUserTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class CreateUserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        $faker = FakerFactory::create();
+
+        return array_merge([
+            'first_name'        => $faker->firstName(),
+            'last_name'         => $faker->lastName(),
+            'email'             => $faker->unique()->safeEmail(),
+            'password'          => $faker->password(8),
+            'age_range'         => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            'subscription_tier' => $faker->randomElement(['free', 'premium']),
+        ], $overrides);
+    }
+
+    public function test_create_user_returns_201_with_user_data(): void
+    {
+        $response = $this->postJson('/api/v1/user/create', $this->validPayload());
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'id',
+                    'first_name',
+                    'last_name',
+                    'email',
+                    'age_range',
+                    'subscription_tier',
+                    'subscription_expires_at',
+                ],
+            ])
+            ->assertJsonFragment(['status' => 'success']);
+    }
+
+    public function test_create_user_returns_500_when_required_key_is_missing(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['email']);
+
+        $response = $this->postJson('/api/v1/user/create', $payload);
+
+        $response->assertStatus(500)
+            ->assertJsonFragment(['status' => 'error']);
+    }
+
+    public function test_create_user_returns_500_on_duplicate_email(): void
+    {
+        $payload = $this->validPayload();
+
+        $this->postJson('/api/v1/user/create', $payload);
+        $response = $this->postJson('/api/v1/user/create', $payload);
+
+        $response->assertStatus(500)
+            ->assertJsonFragment(['status' => 'error']);
+    }
+}

--- a/src/app/Providers/RepositoryProvider.php
+++ b/src/app/Providers/RepositoryProvider.php
@@ -2,26 +2,27 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
-use App\Packages\Domains\WorldHeritageRepositoryInterface;
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Domains\UserRepository;
 use App\Packages\Domains\WorldHeritageRepository;
+use App\Packages\Domains\WorldHeritageRepositoryInterface;
+use Illuminate\Support\ServiceProvider;
 
 class RepositoryProvider extends ServiceProvider
 {
-    /**
-     * Register services.
-     */
     public function register(): void
     {
         $this->app->bind(
             WorldHeritageRepositoryInterface::class,
             WorldHeritageRepository::class
         );
+
+        $this->app->bind(
+            UserRepositroyInterface::class,
+            UserRepository::class
+        );
     }
 
-    /**
-     * Bootstrap services.
-     */
     public function boot(): void
     {
         //

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -14,6 +14,12 @@
             <directory>app</directory>
         </include>
     </source>
+    <coverage>
+        <report>
+            <html outputDirectory="coverage-report"/>
+            <clover outputFile="coverage-report/clover.xml"/>
+        </report>
+    </coverage>
     <php>
         <env name="APP_ENV" value="testing"/>
         <env name="DB_DATABASE" value="world_heritage_test"/>

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -1,11 +1,14 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
+use App\Packages\Features\Controller\UserController;
 use App\Packages\Features\Controller\WorldHeritageController;
+use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function (): void {
     Route::get('/heritages', [WorldHeritageController::class, 'getWorldHeritages']);
     Route::get('/heritages/search', [WorldHeritageController::class, 'searchWorldHeritages']);
     Route::get('heritages/region-count', [WorldHeritageController::class, 'getWorldHeritagesCountByRegion']);
     Route::get('/heritages/{id}', [WorldHeritageController::class, 'getWorldHeritageById']);
+
+    Route::post('/user/create', [UserController::class, 'createUser']);
 });


### PR DESCRIPTION
## Motivation

With the domain, infrastructure, and application layers in place, the presentation layer is needed to expose user creation as an HTTP endpoint. This PR wires up the controller, view model, and route, completing the full vertical slice for user registration.

## What I have done

- Added `password` to `CreateUserCommand` and `UserRepository` to satisfy the `NOT NULL` constraint on the `users` table
- Added `UserViewModel` holding a `UserDto` and exposing `toArray()` for the JSON response
- Added `UserViewModelFactory` to build `UserViewModel` from `UserDto`, following the existing factory pattern
- Added `UserController` with a `createUser` action: on success returns 201 with `UserViewModelFactory::build($dto)->toArray()`; on any error returns 500 to the client and writes full details to `Log::error` for admin visibility
- Registered `POST /api/v1/user/create` in `routes/api.php`
- Bound `UserRepositroyInterface` → `UserRepository` in `RepositoryProvider` so Laravel's container can inject the dependency
- Added `<coverage>` section to `phpunit.xml` (HTML + Clover output); a coverage driver — `pcov` or `xdebug` — must be installed in the container to activate it
- Added integration tests covering: 201 on valid payload, 500 on missing required key, 500 on duplicate email

---

## モチベーション

ドメイン・インフラ・アプリケーション層が揃った状態で、ユーザー登録をHTTPエンドポイントとして公開するプレゼンテーション層が必要でした。このPRでコントローラー・ビューモデル・ルートを繋ぎ合わせ、ユーザー登録の縦断スライスを完成させます。

## 実装内容

- `CreateUserCommand` と `UserRepository` に `password` を追加（`users` テーブルの `NOT NULL` 制約を満たすため）
- `UserViewModel` を追加：`UserDto` を保持し、JSONレスポンス用の `toArray()` を公開
- `UserViewModelFactory` を追加：既存のファクトリパターンに倣い `UserDto` から `UserViewModel` を生成
- `UserController` を追加：成功時は201と `UserViewModelFactory::build($dto)->toArray()` を返却、エラー時はクライアントに500を返しつつ `Log::error` で詳細をadmin向けに記録
- `routes/api.php` に `POST /api/v1/user/create` を登録
- `RepositoryProvider` に `UserRepositroyInterface` → `UserRepository` のバインドを追加
- `phpunit.xml` に `<coverage>` セクション（HTML + Clover出力）を追加。実行には `pcov` または `xdebug` のインストールが必要
- 結合テストを追加：有効データで201・必須キー欠損で500・メール重複で500

## Test Results

```
PASS  App\Packages\Features\Tests\CreateUserTest
✓ create user returns 201 with user data
✓ create user returns 500 when required key is missing
✓ create user returns 500 on duplicate email

Tests: 3 passed (15 assertions)
```