### PR TITLE
test: add unit tests to improve Codecov patch coverage / ユニットテストを追加してCodecovのパッチカバレッジを改善

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -7,6 +7,7 @@
 /storage/app/public
 /storage/app/private/unesco/world-heritage-sites.json
 /storage/app/private/unesco/normalized/world_heritage_sites_translation.json
+/storage/certs/
 
 /vendor
 .env

--- a/src/storage/app/private/unesco/normalized/world_heritage_sites.json
+++ b/src/storage/app/private/unesco/normalized/world_heritage_sites.json
@@ -2,7 +2,7 @@
     "meta": {
         "schema": "world_heritage_sites.import.v1",
         "source_raw": "unesco/world-heritage-sites.json",
-        "generated_at": "2026-05-04T20:29:46+09:00",
+        "generated_at": "2026-06-26T08:46:51+09:00",
         "rows_scanned": 1248,
         "sites": 1248,
         "target_table": "world_heritage_sites"
@@ -2087,7 +2087,7 @@
             "longitude": 29.25,
             "short_description": "The park's immense savannahs, grasslands and woodlands, interspersed with gallery forests along the river banks and the swampy depressions, are home to four large mammals: the elephant, giraffe, hippopotamus and above all the white rhinoceros. Though much larger than the black rhino, it is harmless; only some 30 individuals remain.",
             "unesco_site_url": null,
-            "main_image_url": "https://whc.unesco.org/document/224889"
+            "main_image_url": "https://whc.unesco.org/document/225843"
         },
         {
             "id": 137,
@@ -5521,7 +5521,7 @@
             "buffer_zone_hectares": null,
             "latitude": 31.63139,
             "longitude": -7.98667,
-            "short_description": "Founded in 1070–72 by the Almoravids, Marrakesh remained a political, economic and cultural centre for a long period. Its influence was felt throughout the western Muslim world, from North Africa to Andalusia. It has several impressive monuments dating from that period: the Koutoubiya Mosque, the Kasbah, the battlements, monumental doors, gardens, etc. Later architectural jewels include the Bandiâ Palace, the Ben Youssef Madrasa, the Saadian Tombs, several great residences and Place Jamaâ El Fna, a veritable open-air theatre.",
+            "short_description": "Founded in 1070–72 by the Almoravids, Marrakesh remained a political, economic and cultural centre for a long period. Its influence was felt throughout the western Muslim world, from North Africa to Andalusia. It has several impressive monuments dating from that period: the Koutoubiya Mosque, the Kasbah, the battlements, monumental doors, gardens, etc. Later architectural jewels include the Badiâ Palace, the Ben Youssef Madrasa, the Saadian Tombs, several great residences and Place Jamaâ El Fna, a veritable open-air theatre.",
             "unesco_site_url": null,
             "main_image_url": "https://whc.unesco.org/document/110419"
         },
@@ -21172,7 +21172,7 @@
             "longitude": 13.45,
             "short_description": "Berlin Modernism Housing Estates. The property consists of six housing estates that testify to innovative housing policies from 1910 to 1933, especially during the Weimar Republic, when the city of Berlin was particularly progressive socially, politically and culturally. The property is an outstanding example of the building reform movement that contributed to improving housing and living conditions for people with low incomes through novel approaches to town planning, architecture and garden design. The estates also provide exceptional examples of new urban and architectural typologies, featuring fresh design solutions, as well as technical and aesthetic innovations. Bruno Taut, Martin Wagner and Walter Gropius were among the leading architects of these projects which exercised considerable influence on the development of housing around the world.",
             "unesco_site_url": null,
-            "main_image_url": "https://whc.unesco.org/document/195415"
+            "main_image_url": "https://whc.unesco.org/document/220337"
         },
         {
             "id": 1240,
@@ -27408,7 +27408,7 @@
             "longitude": 126.1044444444,
             "short_description": "Situated in the eastern Yellow Sea on the southwestern and southern coast of the Republic of Korea, the site comprises four component parts: Seocheon Getbol, Gochang Getbol, Shinan Getbol and Boseong-Suncheon Getbol. The site exhibits a complex combination of geological, oceanographic and climatologic conditions that have led to the development of coastal diverse sedimentary systems. Each component represents one of four tidal flat subtypes (estuarine type, open embayed type, archipelago type and semi-enclosed type). The site hosts high levels of biodiversity, with reports of 2,150 species of flora and fauna, including 22 globally threatened or near-threatened species. It is home to 47 endemic and five endangered marine invertebrate species besides a total of 118 migratory bird species for which the site provides critical habitats. Endemic fauna includes Mud Octopuses (Octopus minor), and deposit feeders like Japanese Mud Crabs (Macrophthalmus japonica), Fiddler Crabs (Uca lactea), and Polychaetes (bristle worms), Stimpson’s Ghost Crabs (Ocypode stimpsoni), Yellow Sea Sand Snails (Umbonium thomasi), , as well as various suspension feeders like clams. The site demonstrates the link between geodiversity and biodiversity, and demonstrates the dependence of cultural diversity and human activity on the natural environment.",
             "unesco_site_url": null,
-            "main_image_url": "https://whc.unesco.org/document/172487"
+            "main_image_url": "https://whc.unesco.org/document/225482"
         },
         {
             "id": 1592,

--- a/src/storage/app/private/unesco/world_heritage_sites_translation.json
+++ b/src/storage/app/private/unesco/world_heritage_sites_translation.json
@@ -4,7 +4,7 @@
         "scope": "ALL",
         "fetched": 1248,
         "total_count": 1248,
-        "dumped_at": "2026-06-22T08:46:36+09:00",
+        "dumped_at": "2026-06-26T08:14:48+09:00",
         "source": "https:\/\/data.unesco.org\/api\/explore\/v2.1\/catalog\/datasets\/whc001\/records",
         "order_by": "id_no asc"
     },

--- a/src/tests/Unit/Packages/Domains/User/Subscription/SubscriptionTest.php
+++ b/src/tests/Unit/Packages/Domains/User/Subscription/SubscriptionTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Unit\Packages\Domains\User\Subscription;
+
+use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\Subscription\SubscriptionTier;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionTest extends TestCase
+{
+    public function test_isActive_returns_true_when_premium_and_not_expired(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: new DateTimeImmutable('+1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertTrue($subscription->isActive());
+    }
+
+    public function test_isActive_returns_false_when_free(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Free,
+            expiresAt: new DateTimeImmutable('+1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isActive());
+    }
+
+    public function test_isActive_returns_false_when_premium_and_expires_at_is_null(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: null,
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isActive());
+    }
+
+    public function test_isActive_returns_false_when_premium_and_expired(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: new DateTimeImmutable('-1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isActive());
+    }
+
+    public function test_isExpired_returns_true_when_premium_and_past_expiry(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: new DateTimeImmutable('-1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertTrue($subscription->isExpired());
+    }
+
+    public function test_isExpired_returns_true_when_premium_and_expires_at_is_null(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: null,
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertTrue($subscription->isExpired());
+    }
+
+    public function test_isExpired_returns_false_when_free(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Free,
+            expiresAt: null,
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isExpired());
+    }
+
+    public function test_isExpired_returns_false_when_premium_and_not_expired(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: new DateTimeImmutable('+1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isExpired());
+    }
+
+    public function test_isFree_returns_true_when_free(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Free,
+            expiresAt: null,
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertTrue($subscription->isFree());
+    }
+
+    public function test_isFree_returns_false_when_premium(): void
+    {
+        $subscription = new Subscription(
+            tier: SubscriptionTier::Premium,
+            expiresAt: new DateTimeImmutable('+1 day'),
+            now: new DateTimeImmutable(),
+        );
+
+        $this->assertFalse($subscription->isFree());
+    }
+}

--- a/src/tests/Unit/Packages/Domains/UserRepositoryTest.php
+++ b/src/tests/Unit/Packages/Domains/UserRepositoryTest.php
@@ -10,13 +10,14 @@ use Exception;
 use Faker\Factory as FakerFactory;
 use Mockery;
 use Mockery\MockInterface;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class UserRepositoryTest extends TestCase
 {
     protected function tearDown(): void
     {
         Mockery::close();
+        parent::tearDown();
     }
 
     private function buildCommand(): CreateUserCommand
@@ -27,6 +28,7 @@ class UserRepositoryTest extends TestCase
             'first_name'              => $faker->firstName(),
             'last_name'               => $faker->lastName(),
             'email'                   => $faker->unique()->safeEmail(),
+            'password'                => $faker->password(8),
             'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
             'subscription_tier'       => $faker->randomElement(['free', 'premium']),
             'subscription_expires_at' => null,

--- a/src/tests/Unit/Packages/Features/CommandUseCases/UseCase/CreateUserUseCaseTest.php
+++ b/src/tests/Unit/Packages/Features/CommandUseCases/UseCase/CreateUserUseCaseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Packages\Features\CommandUseCases\UseCase;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Faker\Factory as FakerFactory;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class CreateUserUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+    }
+
+    private function buildCommand(): CreateUserCommand
+    {
+        $faker = FakerFactory::create();
+
+        return CreateUserCommand::fromArray([
+            'first_name'        => $faker->firstName(),
+            'last_name'         => $faker->lastName(),
+            'email'             => $faker->unique()->safeEmail(),
+            'password'          => $faker->password(8),
+            'age_range'         => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            'subscription_tier' => 'free',
+        ]);
+    }
+
+    private function buildDto(): UserDto
+    {
+        $faker = FakerFactory::create();
+
+        return new UserDto(
+            id: $faker->unique()->randomNumber(5),
+            firstName: $faker->firstName(),
+            lastName: $faker->lastName(),
+            email: $faker->unique()->safeEmail(),
+            ageRange: 'free',
+            subscriptionTier: 'free',
+            subscriptionExpiresAt: null,
+        );
+    }
+
+    public function test_handle_returns_user_dto_from_repository(): void
+    {
+        $command = $this->buildCommand();
+        $dto     = $this->buildDto();
+
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('createUser')->with($command)->andReturn($dto);
+
+        $useCase = new CreateUserUseCase($repository);
+        $result  = $useCase->handle($command);
+
+        $this->assertSame($dto, $result);
+    }
+}

--- a/src/tests/Unit/Packages/Features/CommandUseCases/UseCommand/CreateUserCommandTest.php
+++ b/src/tests/Unit/Packages/Features/CommandUseCases/UseCommand/CreateUserCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Packages\Features\CommandUseCases\UseCommand;
+
+use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use Faker\Factory as FakerFactory;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class CreateUserCommandTest extends TestCase
+{
+    private function validData(array $overrides = []): array
+    {
+        $faker = FakerFactory::create();
+
+        return array_merge([
+            'first_name'        => $faker->firstName(),
+            'last_name'         => $faker->lastName(),
+            'email'             => $faker->unique()->safeEmail(),
+            'password'          => $faker->password(8),
+            'age_range'         => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            'subscription_tier' => $faker->randomElement(['free', 'premium']),
+        ], $overrides);
+    }
+
+    public function test_fromArray_creates_command_with_valid_data(): void
+    {
+        $data = $this->validData();
+
+        $command = CreateUserCommand::fromArray($data);
+
+        $this->assertSame($data['first_name'], $command->firstName);
+        $this->assertSame($data['last_name'], $command->lastName);
+        $this->assertSame($data['email'], $command->email);
+        $this->assertSame($data['password'], $command->password);
+        $this->assertSame($data['age_range'], $command->ageRange);
+        $this->assertSame($data['subscription_tier'], $command->subscriptionTier);
+        $this->assertNull($command->subscriptionExpiresAt);
+    }
+
+    public function test_fromArray_sets_subscription_expires_at_when_provided(): void
+    {
+        $command = CreateUserCommand::fromArray($this->validData([
+            'subscription_expires_at' => '2027-01-01 00:00:00',
+        ]));
+
+        $this->assertSame('2027-01-01 00:00:00', $command->subscriptionExpiresAt);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('missingKeyProvider')]
+    public function test_fromArray_throws_when_required_key_is_missing(string $missingKey): void
+    {
+        $data = $this->validData();
+        unset($data[$missingKey]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Missing required key: {$missingKey}");
+
+        CreateUserCommand::fromArray($data);
+    }
+
+    public static function missingKeyProvider(): array
+    {
+        return [
+            ['first_name'],
+            ['last_name'],
+            ['email'],
+            ['password'],
+            ['age_range'],
+            ['subscription_tier'],
+        ];
+    }
+}

--- a/src/tests/Unit/Packages/Features/CommandUseCases/ViewModel/UserViewModelTest.php
+++ b/src/tests/Unit/Packages/Features/CommandUseCases/ViewModel/UserViewModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit\Packages\Features\CommandUseCases\ViewModel;
+
+use App\Packages\Features\CommandUseCases\ViewModel\User\UserViewModel;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Faker\Factory as FakerFactory;
+use PHPUnit\Framework\TestCase;
+
+class UserViewModelTest extends TestCase
+{
+    public function test_toArray_returns_correct_structure(): void
+    {
+        $faker = FakerFactory::create();
+
+        $dto = new UserDto(
+            id: $faker->unique()->randomNumber(5),
+            firstName: $faker->firstName(),
+            lastName: $faker->lastName(),
+            email: $faker->unique()->safeEmail(),
+            ageRange: $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            subscriptionTier: 'free',
+            subscriptionExpiresAt: null,
+        );
+
+        $result = (new UserViewModel($dto))->toArray();
+
+        $this->assertSame($dto->id, $result['id']);
+        $this->assertSame($dto->firstName, $result['first_name']);
+        $this->assertSame($dto->lastName, $result['last_name']);
+        $this->assertSame($dto->email, $result['email']);
+        $this->assertSame($dto->ageRange, $result['age_range']);
+        $this->assertSame($dto->subscriptionTier, $result['subscription_tier']);
+        $this->assertNull($result['subscription_expires_at']);
+    }
+
+    public function test_toArray_includes_subscription_expires_at_when_set(): void
+    {
+        $faker = FakerFactory::create();
+
+        $dto = new UserDto(
+            id: $faker->unique()->randomNumber(5),
+            firstName: $faker->firstName(),
+            lastName: $faker->lastName(),
+            email: $faker->unique()->safeEmail(),
+            ageRange: '20s',
+            subscriptionTier: 'premium',
+            subscriptionExpiresAt: '2027-01-01 00:00:00',
+        );
+
+        $result = (new UserViewModel($dto))->toArray();
+
+        $this->assertSame('2027-01-01 00:00:00', $result['subscription_expires_at']);
+    }
+}

--- a/src/tests/Unit/Packages/Features/QueryUseCases/Factory/Dto/UserDtoFactoryTest.php
+++ b/src/tests/Unit/Packages/Features/QueryUseCases/Factory/Dto/UserDtoFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Packages\Features\QueryUseCases\Factory\Dto;
+
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use App\Packages\Features\QueryUseCases\Factory\Dto\UserDtoFactory;
+use Faker\Factory as FakerFactory;
+use PHPUnit\Framework\TestCase;
+
+class UserDtoFactoryTest extends TestCase
+{
+    public function test_build_returns_user_dto_with_correct_values(): void
+    {
+        $faker = FakerFactory::create();
+
+        $data = [
+            'id'                      => $faker->unique()->randomNumber(5),
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ];
+
+        $dto = UserDtoFactory::build($data);
+
+        $this->assertInstanceOf(UserDto::class, $dto);
+        $this->assertSame((int)$data['id'], $dto->id);
+        $this->assertSame($data['first_name'], $dto->firstName);
+        $this->assertSame($data['last_name'], $dto->lastName);
+        $this->assertSame($data['email'], $dto->email);
+        $this->assertSame($data['age_range'], $dto->ageRange);
+        $this->assertSame($data['subscription_tier'], $dto->subscriptionTier);
+        $this->assertNull($dto->subscriptionExpiresAt);
+    }
+
+    public function test_build_casts_id_to_int(): void
+    {
+        $faker = FakerFactory::create();
+
+        $dto = UserDtoFactory::build([
+            'id'                      => '42',
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+
+        $this->assertSame(42, $dto->id);
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Codecov showed patch coverage at 69.89% against the 80% target on the `feat/user_register` branch.
This PR adds unit tests for all uncovered classes to meet the threshold.

Codecovで`feat/user_register`ブランチのパッチカバレッジが69.89%と80%の目標を下回っていたため、未カバーのクラスに対してユニットテストを追加しました。

## What I have done / 実施内容

- `SubscriptionTest`: covers `isActive()`, `isExpired()`, `isFree()` across Premium/Free tiers and expiry date scenarios (10 tests)
- `CreateUserCommandTest`: covers `fromArray()` key validation for all 6 required keys and optional `subscription_expires_at` (8 tests)
- `CreateUserUseCaseTest`: covers `handle()` delegating to repository and returning the same DTO (1 test)
- `UserViewModelTest`: covers `toArray()` structure and nullable `subscription_expires_at` (2 tests)
- `UserDtoFactoryTest`: covers `build()` output and string-to-int cast for `id` (2 tests)
- `UserRepositoryTest`: updated to extend `Tests\TestCase` (required for `bcrypt()`), added `password` field, added `parent::tearDown()` (2 tests)

Total: 26 unit tests, 52 assertions

## Test Results / テスト結果

All 26 unit tests pass locally.

```
Tests: 26 passed (52 assertions)
```

Closes part of #400