### PR TITLE
test: add unit tests for factories and UserEntity to improve patch coverage / FactoryとUserEntityのユニットテストを追加してパッチカバレッジを改善

### DIFF
--- a/src/tests/Unit/Packages/Domains/User/Factory/SubscriptionFactoryTest.php
+++ b/src/tests/Unit/Packages/Domains/User/Factory/SubscriptionFactoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Packages\Domains\User\Factory;
+
+use App\Packages\Domains\User\Factory\SubscriptionFactory;
+use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\Subscription\SubscriptionTier;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class SubscriptionFactoryTest extends TestCase
+{
+    public function test_build_returns_subscription_with_null_expires_at(): void
+    {
+        $subscription = SubscriptionFactory::build([
+            'tier'       => 'free',
+            'expires_at' => null,
+        ]);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertTrue($subscription->isFree());
+    }
+
+    public function test_build_returns_premium_subscription_with_string_expires_at(): void
+    {
+        $subscription = SubscriptionFactory::build([
+            'tier'       => 'premium',
+            'expires_at' => '2027-01-01 00:00:00',
+        ]);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertFalse($subscription->isFree());
+        $this->assertTrue($subscription->isActive(new DateTimeImmutable('2026-01-01')));
+    }
+
+    public function test_build_accepts_datetime_immutable_for_expires_at(): void
+    {
+        $expiresAt = new DateTimeImmutable('2027-06-01');
+
+        $subscription = SubscriptionFactory::build([
+            'tier'       => 'premium',
+            'expires_at' => $expiresAt,
+        ]);
+
+        $this->assertInstanceOf(Subscription::class, $subscription);
+        $this->assertTrue($subscription->isActive(new DateTimeImmutable('2026-01-01')));
+    }
+
+    public function test_build_accepts_string_for_now(): void
+    {
+        $subscription = SubscriptionFactory::build([
+            'tier'       => 'premium',
+            'expires_at' => '2025-01-01 00:00:00',
+            'now'        => '2026-01-01 00:00:00',
+        ]);
+
+        $this->assertTrue($subscription->isExpired());
+    }
+
+    public function test_build_accepts_datetime_immutable_for_now(): void
+    {
+        $subscription = SubscriptionFactory::build([
+            'tier'       => 'premium',
+            'expires_at' => '2025-01-01 00:00:00',
+            'now'        => new DateTimeImmutable('2026-01-01'),
+        ]);
+
+        $this->assertTrue($subscription->isExpired());
+    }
+}

--- a/src/tests/Unit/Packages/Domains/User/Factory/UserEntityFactoryTest.php
+++ b/src/tests/Unit/Packages/Domains/User/Factory/UserEntityFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Packages\Domains\User\Factory;
+
+use App\Packages\Domains\User\AgeRange;
+use App\Packages\Domains\User\Factory\UserEntityFactory;
+use App\Packages\Domains\User\UserEntity;
+use Faker\Factory as FakerFactory;
+use PHPUnit\Framework\TestCase;
+
+class UserEntityFactoryTest extends TestCase
+{
+    public function test_build_returns_user_entity_with_correct_values(): void
+    {
+        $faker = FakerFactory::create();
+
+        $data = [
+            'id'                      => $faker->unique()->randomNumber(5),
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ];
+
+        $entity = UserEntityFactory::build($data);
+
+        $this->assertInstanceOf(UserEntity::class, $entity);
+        $this->assertSame($data['id'], $entity->getId());
+        $this->assertSame($data['first_name'], $entity->getFirstName());
+        $this->assertSame($data['last_name'], $entity->getLastName());
+        $this->assertSame($data['email'], $entity->getEmail());
+        $this->assertSame(AgeRange::Teens, $entity->getAgeRange());
+        $this->assertTrue($entity->getSubscription()->isFree());
+    }
+
+    public function test_build_passes_expires_at_to_subscription(): void
+    {
+        $faker = FakerFactory::create();
+
+        $entity = UserEntityFactory::build([
+            'id'                      => $faker->unique()->randomNumber(5),
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => '20s',
+            'subscription_tier'       => 'premium',
+            'subscription_expires_at' => '2027-01-01 00:00:00',
+        ]);
+
+        $this->assertFalse($entity->getSubscription()->isFree());
+    }
+}

--- a/src/tests/Unit/Packages/Domains/User/UserEntityTest.php
+++ b/src/tests/Unit/Packages/Domains/User/UserEntityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Packages\Domains\User;
+
+use App\Packages\Domains\User\AgeRange;
+use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\Subscription\SubscriptionTier;
+use App\Packages\Domains\User\UserEntity;
+use Faker\Factory as FakerFactory;
+use PHPUnit\Framework\TestCase;
+
+class UserEntityTest extends TestCase
+{
+    private function buildEntity(array $overrides = []): UserEntity
+    {
+        $faker = FakerFactory::create();
+
+        $subscription = new Subscription(SubscriptionTier::Free, null);
+
+        return new UserEntity(
+            $overrides['id']           ?? $faker->unique()->randomNumber(5),
+            $overrides['first_name']   ?? $faker->firstName(),
+            $overrides['last_name']    ?? $faker->lastName(),
+            $overrides['email']        ?? $faker->unique()->safeEmail(),
+            $overrides['age_range']    ?? AgeRange::Twenties,
+            $overrides['subscription'] ?? $subscription,
+        );
+    }
+
+    public function test_getId_returns_correct_value(): void
+    {
+        $entity = $this->buildEntity(['id' => 42]);
+        $this->assertSame(42, $entity->getId());
+    }
+
+    public function test_getFirstName_returns_correct_value(): void
+    {
+        $entity = $this->buildEntity(['first_name' => 'John']);
+        $this->assertSame('John', $entity->getFirstName());
+    }
+
+    public function test_getLastName_returns_correct_value(): void
+    {
+        $entity = $this->buildEntity(['last_name' => 'Doe']);
+        $this->assertSame('Doe', $entity->getLastName());
+    }
+
+    public function test_getFullName_concatenates_first_and_last_name(): void
+    {
+        $entity = $this->buildEntity(['first_name' => 'John', 'last_name' => 'Doe']);
+        $this->assertSame('John Doe', $entity->getFullName());
+    }
+
+    public function test_getEmail_returns_correct_value(): void
+    {
+        $entity = $this->buildEntity(['email' => 'john@example.com']);
+        $this->assertSame('john@example.com', $entity->getEmail());
+    }
+
+    public function test_getAgeRange_returns_correct_enum(): void
+    {
+        $entity = $this->buildEntity(['age_range' => AgeRange::Thirties]);
+        $this->assertSame(AgeRange::Thirties, $entity->getAgeRange());
+    }
+
+    public function test_getSubscription_returns_subscription_instance(): void
+    {
+        $subscription = new Subscription(SubscriptionTier::Premium, null);
+        $entity       = $this->buildEntity(['subscription' => $subscription]);
+        $this->assertSame($subscription, $entity->getSubscription());
+    }
+}

--- a/src/tests/Unit/Packages/Features/CommandUseCases/Factory/ViewModel/UserViewModelFactoryTest.php
+++ b/src/tests/Unit/Packages/Features/CommandUseCases/Factory/ViewModel/UserViewModelFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Packages\Features\CommandUseCases\Factory\ViewModel;
+
+use App\Packages\Features\CommandUseCases\Factory\ViewModel\UserViewModelFactory;
+use App\Packages\Features\CommandUseCases\ViewModel\User\UserViewModel;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Faker\Factory as FakerFactory;
+use PHPUnit\Framework\TestCase;
+
+class UserViewModelFactoryTest extends TestCase
+{
+    public function test_build_returns_user_view_model(): void
+    {
+        $faker = FakerFactory::create();
+
+        $dto = new UserDto(
+            id: $faker->unique()->randomNumber(5),
+            firstName: $faker->firstName(),
+            lastName: $faker->lastName(),
+            email: $faker->unique()->safeEmail(),
+            ageRange: 'free',
+            subscriptionTier: 'free',
+            subscriptionExpiresAt: null,
+        );
+
+        $viewModel = UserViewModelFactory::build($dto);
+
+        $this->assertInstanceOf(UserViewModel::class, $viewModel);
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

After PR #497, Codecov still reported 69.89% patch coverage (target 85%). Investigation showed the following source files had no unit tests covering them.

PR #497 マージ後も Codecov のパッチカバレッジが 69.89%（目標 85%）のままでした。以下のソースファイルにユニットテストが不足していることが原因と判明しました。

## What I have done / 実施内容

- `SubscriptionFactoryTest`: covers `build()` with null/string/DateTimeImmutable `expires_at`, string/DateTimeImmutable `now` (5 tests)
- `UserEntityFactoryTest`: covers `build()` creating correct `UserEntity` with Free and Premium subscriptions (2 tests)
- `UserEntityTest`: covers all getters including `getFullName()` (7 tests)
- `UserViewModelFactoryTest`: covers `build()` returning `UserViewModel` instance (1 test)

## Test Results / テスト結果

All new tests pass. Previous 26 tests + 15 new = 41 unit tests total.

Closes part of #400