### PR TITLE
refactor: move unit tests to app/Packages/ so phpunit.xml discovers them / ユニットテストをapp/Packages/配下に移動してCIで検出されるように修正

### DIFF
--- a/src/app/Packages/Domains/Tests/User/Factory/SubscriptionFactoryTest.php
+++ b/src/app/Packages/Domains/Tests/User/Factory/SubscriptionFactoryTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Tests\Unit\Packages\Domains\User\Factory;
+namespace App\Packages\Domains\Tests\User\Factory;
 
 use App\Packages\Domains\User\Factory\SubscriptionFactory;
 use App\Packages\Domains\User\Subscription\Subscription;
-use App\Packages\Domains\User\Subscription\SubscriptionTier;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 

--- a/src/app/Packages/Domains/Tests/User/Factory/UserEntityFactoryTest.php
+++ b/src/app/Packages/Domains/Tests/User/Factory/UserEntityFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Domains\User\Factory;
+namespace App\Packages\Domains\Tests\User\Factory;
 
 use App\Packages\Domains\User\AgeRange;
 use App\Packages\Domains\User\Factory\UserEntityFactory;

--- a/src/app/Packages/Domains/Tests/User/Subscription/SubscriptionTest.php
+++ b/src/app/Packages/Domains/Tests/User/Subscription/SubscriptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Domains\User\Subscription;
+namespace App\Packages\Domains\Tests\User\Subscription;
 
 use App\Packages\Domains\User\Subscription\Subscription;
 use App\Packages\Domains\User\Subscription\SubscriptionTier;

--- a/src/app/Packages/Domains/Tests/User/UserEntityTest.php
+++ b/src/app/Packages/Domains/Tests/User/UserEntityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Domains\User;
+namespace App\Packages\Domains\Tests\User;
 
 use App\Packages\Domains\User\AgeRange;
 use App\Packages\Domains\User\Subscription\Subscription;
@@ -13,8 +13,7 @@ class UserEntityTest extends TestCase
 {
     private function buildEntity(array $overrides = []): UserEntity
     {
-        $faker = FakerFactory::create();
-
+        $faker        = FakerFactory::create();
         $subscription = new Subscription(SubscriptionTier::Free, null);
 
         return new UserEntity(

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Domains;
+namespace App\Packages\Domains\Tests;
 
 use App\Models\User;
 use App\Packages\Domains\UserRepository;
@@ -64,7 +64,7 @@ class UserRepositoryTest extends TestCase
     public function test_createUser_returns_user_dto_on_success(): void
     {
         $repository = new UserRepository($this->buildUserModelMock(wasRecentlyCreated: true));
-        $result = $repository->createUser($this->buildCommand());
+        $result     = $repository->createUser($this->buildCommand());
 
         $this->assertInstanceOf(UserDto::class, $result);
     }

--- a/src/app/Packages/Features/Tests/CommandUseCases/CreateUserCommandTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/CreateUserCommandTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Features\CommandUseCases\UseCommand;
+namespace App\Packages\Features\Tests\CommandUseCases;
 
 use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use Faker\Factory as FakerFactory;
@@ -25,8 +25,7 @@ class CreateUserCommandTest extends TestCase
 
     public function test_fromArray_creates_command_with_valid_data(): void
     {
-        $data = $this->validData();
-
+        $data    = $this->validData();
         $command = CreateUserCommand::fromArray($data);
 
         $this->assertSame($data['first_name'], $command->firstName);

--- a/src/app/Packages/Features/Tests/CommandUseCases/CreateUserUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/CreateUserUseCaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Features\CommandUseCases\UseCase;
+namespace App\Packages\Features\Tests\CommandUseCases;
 
 use App\Packages\Domains\Interface\UserRepositroyInterface;
 use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;

--- a/src/app/Packages/Features/Tests/CommandUseCases/UserViewModelFactoryTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/UserViewModelFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Features\CommandUseCases\Factory\ViewModel;
+namespace App\Packages\Features\Tests\CommandUseCases;
 
 use App\Packages\Features\CommandUseCases\Factory\ViewModel\UserViewModelFactory;
 use App\Packages\Features\CommandUseCases\ViewModel\User\UserViewModel;

--- a/src/app/Packages/Features/Tests/CommandUseCases/UserViewModelTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/UserViewModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Features\CommandUseCases\ViewModel;
+namespace App\Packages\Features\Tests\CommandUseCases;
 
 use App\Packages\Features\CommandUseCases\ViewModel\User\UserViewModel;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;

--- a/src/app/Packages/Features/Tests/QueryUseCases/UserDtoFactoryTest.php
+++ b/src/app/Packages/Features/Tests/QueryUseCases/UserDtoFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit\Packages\Features\QueryUseCases\Factory\Dto;
+namespace App\Packages\Features\Tests\QueryUseCases;
 
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 use App\Packages\Features\QueryUseCases\Factory\Dto\UserDtoFactory;


### PR DESCRIPTION
## Motivation / 目的

The `phpunit.xml` testsuite only scans `app/Packages/`, so unit tests placed under `tests/Unit/` were never executed in CI. This meant coverage reports were not reflecting the unit tests at all.

`phpunit.xml` のテストスイートは `app/Packages/` しか走査しないため、`tests/Unit/` に置いたユニットテストはCIで一切実行されていませんでした。そのため、カバレッジレポートにユニットテストの結果が反映されていませんでした。

## What I have done / 実施内容

Moved all unit test files from `tests/Unit/Packages/` to `app/Packages/` and updated namespaces accordingly:

- `tests/Unit/.../Domains/` → `app/Packages/Domains/Tests/`
- `tests/Unit/.../Features/` → `app/Packages/Features/Tests/CommandUseCases/` or `Tests/QueryUseCases/`

Files moved (10 files):
- `SubscriptionTest`, `SubscriptionFactoryTest`, `UserEntityFactoryTest`, `UserEntityTest`, `UserRepositoryTest`
- `CreateUserCommandTest`, `CreateUserUseCaseTest`, `UserViewModelTest`, `UserViewModelFactoryTest`, `UserDtoFactoryTest`

## Test Results / テスト結果

All tests now run under `app/Packages/` and will be discovered by the existing `phpunit.xml` configuration.

Closes part of #400