### PR TITLE
feat: implement findById in Infra layer / Infra層のfindById実装

### DIFF
--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -9,5 +9,7 @@ interface UserRepositroyInterface
 {
     public function createUser(UserEntity $entity): UserDto;
 
+    public function findById(int $id): ?UserDto;
+
     public function updateUser(UserEntity $entity): UserDto;
 }

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -3,147 +3,122 @@
 namespace App\Packages\Domains\Tests;
 
 use App\Models\User;
-use App\Packages\Domains\UserRepository;
+use App\Packages\Domains\User\AgeRange;
 use App\Packages\Domains\User\Factory\UserEntityFactory;
+use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\Subscription\SubscriptionTier;
 use App\Packages\Domains\User\UserEntity;
+use App\Packages\Domains\UserRepository;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
-use Exception;
 use Faker\Factory as FakerFactory;
-use Mockery;
-use Mockery\MockInterface;
-use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class UserRepositoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
     protected function tearDown(): void
     {
-        Mockery::close();
+        $this->truncate();
         parent::tearDown();
     }
 
-    private function buildEntity(): UserEntity
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function repository(): UserRepository
+    {
+        return new UserRepository(new User());
+    }
+
+    private function seedUser(array $overrides = []): User
     {
         $faker = FakerFactory::create();
 
-        return UserEntityFactory::build([
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    private function buildEntity(array $overrides = []): UserEntity
+    {
+        $faker = FakerFactory::create();
+
+        return UserEntityFactory::build(array_merge([
             'id'                      => null,
             'first_name'              => $faker->firstName(),
             'last_name'               => $faker->lastName(),
             'email'                   => $faker->unique()->safeEmail(),
-            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
-            'subscription_tier'       => $faker->randomElement(['free', 'premium']),
-            'subscription_expires_at' => null,
-            'password_hash'           => 'hashed_password',
-        ]);
-    }
-
-    private function buildAttributes(): array
-    {
-        $faker = FakerFactory::create();
-
-        return [
-            'id'                      => $faker->unique()->randomNumber(5),
-            'first_name'              => $faker->firstName(),
-            'last_name'               => $faker->lastName(),
-            'email'                   => $faker->unique()->safeEmail(),
-            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
-            'subscription_tier'       => 'free',
-            'subscription_expires_at' => null,
-        ];
-    }
-
-    private function buildCreateModelMock(bool $wasRecentlyCreated): User
-    {
-        $attributes = $this->buildAttributes();
-
-        /** @var User|MockInterface $createdUser */
-        $createdUser = Mockery::mock(User::class);
-        $createdUser->wasRecentlyCreated = $wasRecentlyCreated;
-        $createdUser->shouldReceive('toArray')->andReturn($attributes);
-
-        /** @var User|MockInterface $userModel */
-        $userModel = Mockery::mock(User::class);
-        $userModel->shouldReceive('create')->andReturn($createdUser);
-
-        return $userModel;
-    }
-
-    private function buildUpdateModelMock(?int $foundId): User
-    {
-        $attributes = $this->buildAttributes();
-
-        /** @var User|MockInterface $userModel */
-        $userModel = Mockery::mock(User::class);
-
-        if ($foundId === null) {
-            $userModel->shouldReceive('find')->andReturn(null);
-        } else {
-            /** @var User|MockInterface $foundUser */
-            $foundUser = Mockery::mock(User::class)->makePartial();
-            $foundUser->shouldReceive('update')->andReturn(true);
-            $foundUser->shouldReceive('refresh')->andReturn(null);
-            $foundUser->shouldReceive('toArray')->andReturn($attributes);
-
-            $userModel->shouldReceive('find')->with($foundId)->andReturn($foundUser);
-        }
-
-        return $userModel;
-    }
-
-    public function test_createUser_returns_user_dto_on_success(): void
-    {
-        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: true));
-        $result     = $repository->createUser($this->buildEntity());
-
-        $this->assertInstanceOf(UserDto::class, $result);
-    }
-
-    public function test_createUser_throws_exception_when_insert_fails(): void
-    {
-        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: false));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Failed to create user.');
-
-        $repository->createUser($this->buildEntity());
-    }
-
-    public function test_updateUser_returns_user_dto_on_success(): void
-    {
-        $existingId = 1;
-        $entity     = UserEntityFactory::build([
-            'id'                      => $existingId,
-            'first_name'              => 'Updated',
-            'last_name'               => 'Name',
-            'email'                   => 'updated@example.com',
             'age_range'               => 'teens',
             'subscription_tier'       => 'free',
             'subscription_expires_at' => null,
-        ]);
+            'password_hash'           => bcrypt('password'),
+        ], $overrides));
+    }
 
-        $repository = new UserRepository($this->buildUpdateModelMock(foundId: $existingId));
-        $result     = $repository->updateUser($entity);
+    public function test_createUser_persists_user_and_returns_dto(): void
+    {
+        $result = $this->repository()->createUser($this->buildEntity());
 
         $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertDatabaseHas('users', ['email' => $result->email]);
+    }
+
+    public function test_findById_returns_user_dto_when_user_exists(): void
+    {
+        $user   = $this->seedUser();
+        $result = $this->repository()->findById($user->id);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertSame($user->id, $result->id);
+        $this->assertSame($user->email, $result->email);
+    }
+
+    public function test_findById_returns_null_when_user_not_found(): void
+    {
+        $result = $this->repository()->findById(999999);
+
+        $this->assertNull($result);
+    }
+
+    public function test_updateUser_persists_changes_and_returns_dto(): void
+    {
+        $user   = $this->seedUser(['email' => 'before@example.com']);
+        $entity = $this->buildEntity([
+            'id'    => $user->id,
+            'email' => 'after@example.com',
+        ]);
+
+        $result = $this->repository()->updateUser($entity);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => 'after@example.com']);
     }
 
     public function test_updateUser_throws_exception_when_user_not_found(): void
     {
-        $entity = UserEntityFactory::build([
-            'id'                      => 999,
-            'first_name'              => 'Ghost',
-            'last_name'               => 'User',
-            'email'                   => 'ghost@example.com',
-            'age_range'               => 'teens',
-            'subscription_tier'       => 'free',
-            'subscription_expires_at' => null,
-        ]);
+        $entity = $this->buildEntity(['id' => 999999]);
 
-        $repository = new UserRepository($this->buildUpdateModelMock(foundId: null));
-
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('User not found.');
 
-        $repository->updateUser($entity);
+        $this->repository()->updateUser($entity);
     }
 }

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -34,6 +34,17 @@ class UserRepository implements UserRepositroyInterface
         return UserDtoFactory::build($insertUser->toArray());
     }
 
+    public function findById(int $id): ?UserDto
+    {
+        $user = $this->userModel->find($id);
+
+        if ($user === null) {
+            return null;
+        }
+
+        return UserDtoFactory::build($user->toArray());
+    }
+
     public function updateUser(UserEntity $entity): UserDto
     {
         $user = $this->userModel->find($entity->getId());


### PR DESCRIPTION
## Motivation / 目的

`findById` is required by the Application layer (`UpdateUserUseCase`) to fetch the current user data before merging and overwriting fields.

Application層（`UpdateUserUseCase`）がユーザーデータを取得してマージするために、`findById` が必要です。

## What I have done / 実施内容

- `UserRepositroyInterface`: add `findById(int $id): ?UserDto`
- `UserRepository`: implement `findById`
  - Find user by ID via `find()`, return `null` if not found
  - Return as `UserDto` via `UserDtoFactory`

## Test / テスト

Rewrote `UserRepositoryTest` from Mockery-based unit tests to real DB integration tests.

`UserRepositoryTest` をMockeryモックから実DBを使った統合テストに全面書き換えました。

- `test_createUser_persists_user_and_returns_dto`
- `test_findById_returns_user_dto_when_user_exists`
- `test_findById_returns_null_when_user_not_found`
- `test_updateUser_persists_changes_and_returns_dto`
- `test_updateUser_throws_exception_when_user_not_found`

Closes #506