### PR TITLE
feat: implement Presentation layer for GET /api/v1/users/{id} / Presentation層のuserById実装

### DIFF
--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -6,12 +6,44 @@ use App\Http\Controllers\Controller;
 use App\Packages\Features\CommandUseCases\Factory\ViewModel\UserViewModelFactory;
 use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use App\Packages\Features\QueryUseCases\UseCase\User\GetUserByIdUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
 class UserController extends Controller
 {
+    public function getUserById(
+        Request $request,
+        GetUserByIdUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $dto = $useCase->handle($request->route('id'));
+
+            return response()->json([
+                'status' => 'success',
+                'data'   => UserViewModelFactory::build($dto)->toArray(),
+            ], 200);
+        } catch (\Exception $exception) {
+            if ($exception->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to get user by id', [
+                'message' => $exception->getMessage(),
+                'trace'   => $exception->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
     public function createUser(
         Request $request,
         CreateUserUseCase $useCase,

--- a/src/app/Packages/Features/Tests/GetUserByIdTest.php
+++ b/src/app/Packages/Features/Tests/GetUserByIdTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GetUserByIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(array $overrides = []): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    public function test_get_user_by_id_returns_200_with_user_data(): void
+    {
+        $user = $this->seedUser();
+
+        $response = $this->getJson("/api/v1/users/{$user->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'id',
+                    'first_name',
+                    'last_name',
+                    'email',
+                    'age_range',
+                    'subscription_tier',
+                    'subscription_expires_at',
+                ],
+            ])
+            ->assertJsonFragment([
+                'status' => 'success',
+                'id'     => $user->id,
+                'email'  => $user->email,
+            ]);
+    }
+
+    public function test_get_user_by_id_returns_404_when_user_not_found(): void
+    {
+        $response = $this->getJson('/api/v1/users/999999');
+
+        $response->assertStatus(404)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'User not found.',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -10,5 +10,6 @@ Route::prefix('v1')->group(function (): void {
     Route::get('heritages/region-count', [WorldHeritageController::class, 'getWorldHeritagesCountByRegion']);
     Route::get('/heritages/{id}', [WorldHeritageController::class, 'getWorldHeritageById']);
 
+    Route::get('/users/{id}', [UserController::class, 'getUserById']);
     Route::post('/user/create', [UserController::class, 'createUser']);
 });


### PR DESCRIPTION
## Motivation / 目的

Implement the Controller and route for the User findById API as part of #507.

#507 の一環として、ユーザー取得APIのControllerとRouteを実装しました。

## What I have done / 実施内容

- `UserController::getUserById()`: call `GetUserByIdUseCase` and return `UserDto` as JSON
  - 200 on success
  - 404 when `'User not found.'` exception is thrown
  - 500 on other errors with `Log::error`
- Route: `GET /api/v1/users/{id}`

## Test Results / テスト結果

Integration tests hitting the real DB and HTTP endpoint:

- `test_get_user_by_id_returns_200_with_user_data`
- `test_get_user_by_id_returns_404_when_user_not_found`

Closes #509