### PR TITLE
feat: implement GET /api/v1/users/{id} - User findById API

### DIFF
--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -9,5 +9,7 @@ interface UserRepositroyInterface
 {
     public function createUser(UserEntity $entity): UserDto;
 
+    public function findById(int $id): ?UserDto;
+
     public function updateUser(UserEntity $entity): UserDto;
 }

--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -8,4 +8,6 @@ use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 interface UserRepositroyInterface
 {
     public function createUser(UserEntity $entity): UserDto;
+
+    public function updateUser(UserEntity $entity): UserDto;
 }

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -3,147 +3,122 @@
 namespace App\Packages\Domains\Tests;
 
 use App\Models\User;
-use App\Packages\Domains\UserRepository;
+use App\Packages\Domains\User\AgeRange;
 use App\Packages\Domains\User\Factory\UserEntityFactory;
+use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\Subscription\SubscriptionTier;
 use App\Packages\Domains\User\UserEntity;
+use App\Packages\Domains\UserRepository;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
-use Exception;
 use Faker\Factory as FakerFactory;
-use Mockery;
-use Mockery\MockInterface;
-use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
 
 class UserRepositoryTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
     protected function tearDown(): void
     {
-        Mockery::close();
+        $this->truncate();
         parent::tearDown();
     }
 
-    private function buildEntity(): UserEntity
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function repository(): UserRepository
+    {
+        return new UserRepository(new User());
+    }
+
+    private function seedUser(array $overrides = []): User
     {
         $faker = FakerFactory::create();
 
-        return UserEntityFactory::build([
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    private function buildEntity(array $overrides = []): UserEntity
+    {
+        $faker = FakerFactory::create();
+
+        return UserEntityFactory::build(array_merge([
             'id'                      => null,
             'first_name'              => $faker->firstName(),
             'last_name'               => $faker->lastName(),
             'email'                   => $faker->unique()->safeEmail(),
-            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
-            'subscription_tier'       => $faker->randomElement(['free', 'premium']),
-            'subscription_expires_at' => null,
-            'password_hash'           => 'hashed_password',
-        ]);
-    }
-
-    private function buildAttributes(): array
-    {
-        $faker = FakerFactory::create();
-
-        return [
-            'id'                      => $faker->unique()->randomNumber(5),
-            'first_name'              => $faker->firstName(),
-            'last_name'               => $faker->lastName(),
-            'email'                   => $faker->unique()->safeEmail(),
-            'age_range'               => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
-            'subscription_tier'       => 'free',
-            'subscription_expires_at' => null,
-        ];
-    }
-
-    private function buildCreateModelMock(bool $wasRecentlyCreated): User
-    {
-        $attributes = $this->buildAttributes();
-
-        /** @var User|MockInterface $createdUser */
-        $createdUser = Mockery::mock(User::class);
-        $createdUser->wasRecentlyCreated = $wasRecentlyCreated;
-        $createdUser->shouldReceive('toArray')->andReturn($attributes);
-
-        /** @var User|MockInterface $userModel */
-        $userModel = Mockery::mock(User::class);
-        $userModel->shouldReceive('create')->andReturn($createdUser);
-
-        return $userModel;
-    }
-
-    private function buildUpdateModelMock(?int $foundId): User
-    {
-        $attributes = $this->buildAttributes();
-
-        /** @var User|MockInterface $userModel */
-        $userModel = Mockery::mock(User::class);
-
-        if ($foundId === null) {
-            $userModel->shouldReceive('find')->andReturn(null);
-        } else {
-            /** @var User|MockInterface $foundUser */
-            $foundUser = Mockery::mock(User::class)->makePartial();
-            $foundUser->shouldReceive('update')->andReturn(true);
-            $foundUser->shouldReceive('refresh')->andReturn(null);
-            $foundUser->shouldReceive('toArray')->andReturn($attributes);
-
-            $userModel->shouldReceive('find')->with($foundId)->andReturn($foundUser);
-        }
-
-        return $userModel;
-    }
-
-    public function test_createUser_returns_user_dto_on_success(): void
-    {
-        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: true));
-        $result     = $repository->createUser($this->buildEntity());
-
-        $this->assertInstanceOf(UserDto::class, $result);
-    }
-
-    public function test_createUser_throws_exception_when_insert_fails(): void
-    {
-        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: false));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Failed to create user.');
-
-        $repository->createUser($this->buildEntity());
-    }
-
-    public function test_updateUser_returns_user_dto_on_success(): void
-    {
-        $existingId = 1;
-        $entity     = UserEntityFactory::build([
-            'id'                      => $existingId,
-            'first_name'              => 'Updated',
-            'last_name'               => 'Name',
-            'email'                   => 'updated@example.com',
             'age_range'               => 'teens',
             'subscription_tier'       => 'free',
             'subscription_expires_at' => null,
-        ]);
+            'password_hash'           => bcrypt('password'),
+        ], $overrides));
+    }
 
-        $repository = new UserRepository($this->buildUpdateModelMock(foundId: $existingId));
-        $result     = $repository->updateUser($entity);
+    public function test_createUser_persists_user_and_returns_dto(): void
+    {
+        $result = $this->repository()->createUser($this->buildEntity());
 
         $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertDatabaseHas('users', ['email' => $result->email]);
+    }
+
+    public function test_findById_returns_user_dto_when_user_exists(): void
+    {
+        $user   = $this->seedUser();
+        $result = $this->repository()->findById($user->id);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertSame($user->id, $result->id);
+        $this->assertSame($user->email, $result->email);
+    }
+
+    public function test_findById_returns_null_when_user_not_found(): void
+    {
+        $result = $this->repository()->findById(999999);
+
+        $this->assertNull($result);
+    }
+
+    public function test_updateUser_persists_changes_and_returns_dto(): void
+    {
+        $user   = $this->seedUser(['email' => 'before@example.com']);
+        $entity = $this->buildEntity([
+            'id'    => $user->id,
+            'email' => 'after@example.com',
+        ]);
+
+        $result = $this->repository()->updateUser($entity);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+        $this->assertDatabaseHas('users', ['id' => $user->id, 'email' => 'after@example.com']);
     }
 
     public function test_updateUser_throws_exception_when_user_not_found(): void
     {
-        $entity = UserEntityFactory::build([
-            'id'                      => 999,
-            'first_name'              => 'Ghost',
-            'last_name'               => 'User',
-            'email'                   => 'ghost@example.com',
-            'age_range'               => 'teens',
-            'subscription_tier'       => 'free',
-            'subscription_expires_at' => null,
-        ]);
+        $entity = $this->buildEntity(['id' => 999999]);
 
-        $repository = new UserRepository($this->buildUpdateModelMock(foundId: null));
-
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('User not found.');
 
-        $repository->updateUser($entity);
+        $this->repository()->updateUser($entity);
     }
 }

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -37,11 +37,11 @@ class UserRepositoryTest extends TestCase
         ]);
     }
 
-    private function buildUserModelMock(bool $wasRecentlyCreated): User
+    private function buildAttributes(): array
     {
         $faker = FakerFactory::create();
 
-        $attributes = [
+        return [
             'id'                      => $faker->unique()->randomNumber(5),
             'first_name'              => $faker->firstName(),
             'last_name'               => $faker->lastName(),
@@ -50,6 +50,11 @@ class UserRepositoryTest extends TestCase
             'subscription_tier'       => 'free',
             'subscription_expires_at' => null,
         ];
+    }
+
+    private function buildCreateModelMock(bool $wasRecentlyCreated): User
+    {
+        $attributes = $this->buildAttributes();
 
         /** @var User|MockInterface $createdUser */
         $createdUser = Mockery::mock(User::class);
@@ -63,9 +68,31 @@ class UserRepositoryTest extends TestCase
         return $userModel;
     }
 
+    private function buildUpdateModelMock(?int $foundId): User
+    {
+        $attributes = $this->buildAttributes();
+
+        /** @var User|MockInterface $userModel */
+        $userModel = Mockery::mock(User::class);
+
+        if ($foundId === null) {
+            $userModel->shouldReceive('find')->andReturn(null);
+        } else {
+            /** @var User|MockInterface $foundUser */
+            $foundUser = Mockery::mock(User::class)->makePartial();
+            $foundUser->shouldReceive('update')->andReturn(true);
+            $foundUser->shouldReceive('refresh')->andReturn(null);
+            $foundUser->shouldReceive('toArray')->andReturn($attributes);
+
+            $userModel->shouldReceive('find')->with($foundId)->andReturn($foundUser);
+        }
+
+        return $userModel;
+    }
+
     public function test_createUser_returns_user_dto_on_success(): void
     {
-        $repository = new UserRepository($this->buildUserModelMock(wasRecentlyCreated: true));
+        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: true));
         $result     = $repository->createUser($this->buildEntity());
 
         $this->assertInstanceOf(UserDto::class, $result);
@@ -73,11 +100,50 @@ class UserRepositoryTest extends TestCase
 
     public function test_createUser_throws_exception_when_insert_fails(): void
     {
-        $repository = new UserRepository($this->buildUserModelMock(wasRecentlyCreated: false));
+        $repository = new UserRepository($this->buildCreateModelMock(wasRecentlyCreated: false));
 
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to create user.');
 
         $repository->createUser($this->buildEntity());
+    }
+
+    public function test_updateUser_returns_user_dto_on_success(): void
+    {
+        $existingId = 1;
+        $entity     = UserEntityFactory::build([
+            'id'                      => $existingId,
+            'first_name'              => 'Updated',
+            'last_name'               => 'Name',
+            'email'                   => 'updated@example.com',
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+
+        $repository = new UserRepository($this->buildUpdateModelMock(foundId: $existingId));
+        $result     = $repository->updateUser($entity);
+
+        $this->assertInstanceOf(UserDto::class, $result);
+    }
+
+    public function test_updateUser_throws_exception_when_user_not_found(): void
+    {
+        $entity = UserEntityFactory::build([
+            'id'                      => 999,
+            'first_name'              => 'Ghost',
+            'last_name'               => 'User',
+            'email'                   => 'ghost@example.com',
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+
+        $repository = new UserRepository($this->buildUpdateModelMock(foundId: null));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $repository->updateUser($entity);
     }
 }

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -34,6 +34,17 @@ class UserRepository implements UserRepositroyInterface
         return UserDtoFactory::build($insertUser->toArray());
     }
 
+    public function findById(int $id): ?UserDto
+    {
+        $user = $this->userModel->find($id);
+
+        if ($user === null) {
+            return null;
+        }
+
+        return UserDtoFactory::build($user->toArray());
+    }
+
     public function updateUser(UserEntity $entity): UserDto
     {
         $user = $this->userModel->find($entity->getId());

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -33,4 +33,26 @@ class UserRepository implements UserRepositroyInterface
 
         return UserDtoFactory::build($insertUser->toArray());
     }
+
+    public function updateUser(UserEntity $entity): UserDto
+    {
+        $user = $this->userModel->find($entity->getId());
+
+        if ($user === null) {
+            throw new Exception('User not found.');
+        }
+
+        $user->update([
+            'first_name'              => $entity->getFirstName(),
+            'last_name'               => $entity->getLastName(),
+            'email'                   => $entity->getEmail(),
+            'age_range'               => $entity->getAgeRange()->value,
+            'subscription_tier'       => $entity->getSubscription()->getTier()->value,
+            'subscription_expires_at' => $entity->getSubscription()->getExpiresAt()?->format('Y-m-d H:i:s'),
+        ]);
+
+        $user->refresh();
+
+        return UserDtoFactory::build($user->toArray());
+    }
 }

--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -6,12 +6,44 @@ use App\Http\Controllers\Controller;
 use App\Packages\Features\CommandUseCases\Factory\ViewModel\UserViewModelFactory;
 use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
+use App\Packages\Features\QueryUseCases\UseCase\User\GetUserByIdUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 
 class UserController extends Controller
 {
+    public function getUserById(
+        Request $request,
+        GetUserByIdUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $dto = $useCase->handle($request->route('id'));
+
+            return response()->json([
+                'status' => 'success',
+                'data'   => UserViewModelFactory::build($dto)->toArray(),
+            ], 200);
+        } catch (\Exception $exception) {
+            if ($exception->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to get user by id', [
+                'message' => $exception->getMessage(),
+                'trace'   => $exception->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
     public function createUser(
         Request $request,
         CreateUserUseCase $useCase,

--- a/src/app/Packages/Features/QueryUseCases/Tests/UseCase/GetUserByIdUseCaseTest.php
+++ b/src/app/Packages/Features/QueryUseCases/Tests/UseCase/GetUserByIdUseCaseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Packages\Features\QueryUseCases\Tests\UseCase;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use App\Packages\Features\QueryUseCases\UseCase\User\GetUserByIdUseCase;
+use Exception;
+use Faker\Factory as FakerFactory;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class GetUserByIdUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function buildDto(): UserDto
+    {
+        $faker = FakerFactory::create();
+
+        return new UserDto(
+            id:                    $faker->unique()->randomNumber(5),
+            firstName:             $faker->firstName(),
+            lastName:              $faker->lastName(),
+            email:                 $faker->unique()->safeEmail(),
+            ageRange:              'teens',
+            subscriptionTier:      'free',
+            subscriptionExpiresAt: null,
+        );
+    }
+
+    public function test_handle_returns_user_dto_when_user_exists(): void
+    {
+        $dto = $this->buildDto();
+
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->once()
+            ->with($dto->id)
+            ->andReturn($dto);
+
+        $result = (new GetUserByIdUseCase($repository))->handle($dto->id);
+
+        $this->assertSame($dto, $result);
+    }
+
+    public function test_handle_throws_exception_when_user_not_found(): void
+    {
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->once()
+            ->with(999)
+            ->andReturn(null);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        (new GetUserByIdUseCase($repository))->handle(999);
+    }
+}

--- a/src/app/Packages/Features/QueryUseCases/UseCase/User/GetUserByIdUseCase.php
+++ b/src/app/Packages/Features/QueryUseCases/UseCase/User/GetUserByIdUseCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Packages\Features\QueryUseCases\UseCase\User;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Exception;
+
+final class GetUserByIdUseCase
+{
+    public function __construct(
+        private readonly UserRepositroyInterface $userRepository,
+    ) {}
+
+    public function handle(int $id): UserDto
+    {
+        $userDto = $this->userRepository->findById($id);
+
+        if ($userDto === null) {
+            throw new Exception('User not found.');
+        }
+
+        return $userDto;
+    }
+}

--- a/src/app/Packages/Features/Tests/GetUserByIdTest.php
+++ b/src/app/Packages/Features/Tests/GetUserByIdTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GetUserByIdTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(array $overrides = []): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    public function test_get_user_by_id_returns_200_with_user_data(): void
+    {
+        $user = $this->seedUser();
+
+        $response = $this->getJson("/api/v1/users/{$user->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'data' => [
+                    'id',
+                    'first_name',
+                    'last_name',
+                    'email',
+                    'age_range',
+                    'subscription_tier',
+                    'subscription_expires_at',
+                ],
+            ])
+            ->assertJsonFragment([
+                'status' => 'success',
+                'id'     => $user->id,
+                'email'  => $user->email,
+            ]);
+    }
+
+    public function test_get_user_by_id_returns_404_when_user_not_found(): void
+    {
+        $response = $this->getJson('/api/v1/users/999999');
+
+        $response->assertStatus(404)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'User not found.',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -10,5 +10,6 @@ Route::prefix('v1')->group(function (): void {
     Route::get('heritages/region-count', [WorldHeritageController::class, 'getWorldHeritagesCountByRegion']);
     Route::get('/heritages/{id}', [WorldHeritageController::class, 'getWorldHeritageById']);
 
+    Route::get('/users/{id}', [UserController::class, 'getUserById']);
     Route::post('/user/create', [UserController::class, 'createUser']);
 });


### PR DESCRIPTION
## Motivation / 目的

Implement the User findById API (`GET /api/v1/users/{id}`) to allow fetching a single user by their ID.

ユーザーIDによる単一ユーザー取得API（`GET /api/v1/users/{id}`）を実装しました。

## What I have done / 実施内容

### Infra層
- `UserRepositroyInterface`: add `findById(int $id): ?UserDto`
- `UserRepository`: implement `findById` — find by ID, return `null` if not found

### Application層
- `GetUserByIdUseCase`: call `UserRepositroyInterface::findById()`, throw `Exception` if not found, return `UserDto`

### Presentation層
- `UserController::getUserById()`: 200 on success, 404 when not found, 500 on other errors
- Route: `GET /api/v1/users/{id}`

## Test Results / テスト結果

- `UserRepositoryTest`: DB integration tests for `findById`
- `GetUserByIdUseCaseTest`: unit tests with Mockery
- `GetUserByIdTest`: integration tests for `GET /api/v1/users/{id}`

Closes #507