### PR TITLE
feat: implement deleteUser in Infra layer / Infra層のdeleteUser実装

### DIFF
--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -12,4 +12,6 @@ interface UserRepositroyInterface
     public function findById(int $id): ?UserDto;
 
     public function updateUser(UserEntity $entity): UserDto;
+
+    public function deleteUser(int $id): void;
 }

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -121,4 +121,21 @@ class UserRepositoryTest extends TestCase
 
         $this->repository()->updateUser($entity);
     }
+
+    public function test_deleteUser_removes_user_when_exists(): void
+    {
+        $user = $this->seedUser();
+
+        $this->repository()->deleteUser($user->id);
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_deleteUser_throws_exception_when_user_not_found(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->repository()->deleteUser(999999);
+    }
 }

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -66,4 +66,15 @@ class UserRepository implements UserRepositroyInterface
 
         return UserDtoFactory::build($user->toArray());
     }
+
+    public function deleteUser(int $id): void
+    {
+        $user = $this->userModel->find($id);
+
+        if ($user === null) {
+            throw new Exception('User not found.');
+        }
+
+        $user->delete();
+    }
 }


### PR DESCRIPTION
## Motivation / 目的

Implement the repository layer for deleting user data as part of the User Delete API (#514).

ユーザー削除APIのInfra層（#515）として、ユーザーデータを削除するリポジトリ層を実装しました。

## What I have done / 実施内容

- `UserRepositroyInterface`: `deleteUser(int $id): void` を追加
- `UserRepository`: `deleteUser` を実装
  - IDでユーザーを検索し、存在しない場合は `Exception('User not found.')` をスロー
  - `delete()` でレコードを削除
- `UserRepositoryTest`: DBインテグレーションテストを2件追加

## Test Results / テスト結果

- `test_deleteUser_removes_user_when_exists`
- `test_deleteUser_throws_exception_when_user_not_found`

Closes #515