### PR TITLE
feat: implement Application layer for User Delete API / Application層のDeleteUserUseCase実装

### DIFF
--- a/src/app/Packages/Features/CommandUseCases/UseCase/User/DeleteUserUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/User/DeleteUserUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCase\User;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+
+final class DeleteUserUseCase
+{
+    public function __construct(
+        private readonly UserRepositroyInterface $userRepository,
+    ) {}
+
+    public function handle(int $id): void
+    {
+        $this->userRepository->deleteUser($id);
+    }
+}

--- a/src/app/Packages/Features/Tests/CommandUseCases/DeleteUserUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/DeleteUserUseCaseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Packages\Features\Tests\CommandUseCases;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\CommandUseCases\UseCase\User\DeleteUserUseCase;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class DeleteUserUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test_handle_calls_repository_deleteUser_with_given_id(): void
+    {
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('deleteUser')
+            ->once()
+            ->with(1);
+
+        (new DeleteUserUseCase($repository))->handle(1);
+    }
+
+    public function test_handle_propagates_exception_when_user_not_found(): void
+    {
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('deleteUser')
+            ->once()
+            ->with(999999)
+            ->andThrow(new \Exception('User not found.'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        (new DeleteUserUseCase($repository))->handle(999999);
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Implement the Application layer for the User Delete API as part of #514.

ユーザー削除APIのApplication層（#516）として、`DeleteUserUseCase` を実装しました。

## What I have done / 実施内容

- `DeleteUserUseCase`: `handle(int $id): void`
  - Command オブジェクト不要（削除に必要なのは ID のみ）
  - `UserRepositroyInterface::deleteUser()` を呼び出し、例外はリポジトリから自動伝播

## Test Results / テスト結果

- `test_handle_calls_repository_deleteUser_with_given_id`
- `test_handle_propagates_exception_when_user_not_found`

Closes #516