### PR TITLE
feat: implement Presentation layer for DELETE /api/v1/users/{id} / ユーザー削除APIのPresentation層実装

### DIFF
--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -5,6 +5,7 @@ namespace App\Packages\Features\Controller;
 use App\Http\Controllers\Controller;
 use App\Packages\Features\QueryUseCases\Factory\ViewModel\UserViewModelFactory;
 use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
+use App\Packages\Features\CommandUseCases\UseCase\User\DeleteUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCase\User\UpdateUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use App\Packages\Features\CommandUseCases\UseCommand\User\UpdateUserCommand;
@@ -70,6 +71,36 @@ class UserController extends Controller
             }
 
             Log::error('Failed to update user', [
+                'message' => $exception->getMessage(),
+                'trace'   => $exception->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
+    public function deleteUser(
+        Request $request,
+        DeleteUserUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $useCase->handle((int) $request->route('id'));
+
+            return response()->json([
+                'status' => 'success',
+            ], 200);
+        } catch (\Exception $exception) {
+            if ($exception->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to delete user', [
                 'message' => $exception->getMessage(),
                 'trace'   => $exception->getTraceAsString(),
             ]);

--- a/src/app/Packages/Features/Tests/DeleteUserTest.php
+++ b/src/app/Packages/Features/Tests/DeleteUserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeleteUserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(array $overrides = []): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    public function test_delete_user_returns_200_when_user_exists(): void
+    {
+        $user = $this->seedUser();
+
+        $response = $this->deleteJson("/api/v1/users/{$user->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['status' => 'success']);
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_delete_user_returns_404_when_user_not_found(): void
+    {
+        $response = $this->deleteJson('/api/v1/users/999999');
+
+        $response->assertStatus(404)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'User not found.',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -12,5 +12,6 @@ Route::prefix('v1')->group(function (): void {
 
     Route::get('/users/{id}', [UserController::class, 'getUserById']);
     Route::patch('/users/{id}', [UserController::class, 'updateUser']);
+    Route::delete('/users/{id}', [UserController::class, 'deleteUser']);
     Route::post('/user/create', [UserController::class, 'createUser']);
 });


### PR DESCRIPTION
## Motivation / 目的

Implement the Controller and route for the User Delete API as part of #514.

ユーザー削除APIのPresentation層（#517）として、ControllerとRouteを実装しました。

## What I have done / 実施内容

- `UserController::deleteUser()`: route `{id}` を int にキャストして `DeleteUserUseCase` を呼び出す
  - 200 on success
  - 404 when `'User not found.'` exception is thrown
  - 500 on other errors with `Log::error`
- Route: `DELETE /api/v1/users/{id}`

## Test Results / テスト結果

Integration tests hitting the real DB and HTTP endpoint:

- `test_delete_user_returns_200_when_user_exists`
- `test_delete_user_returns_404_when_user_not_found`

Closes #517