### PR TITLE
feat: implement User Delete API / ユーザー削除APIの実装

### DIFF
--- a/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/Interface/UserRepositroyInterface.php
@@ -12,4 +12,6 @@ interface UserRepositroyInterface
     public function findById(int $id): ?UserDto;
 
     public function updateUser(UserEntity $entity): UserDto;
+
+    public function deleteUser(int $id): void;
 }

--- a/src/app/Packages/Domains/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/Tests/UserRepositoryTest.php
@@ -121,4 +121,21 @@ class UserRepositoryTest extends TestCase
 
         $this->repository()->updateUser($entity);
     }
+
+    public function test_deleteUser_removes_user_when_exists(): void
+    {
+        $user = $this->seedUser();
+
+        $this->repository()->deleteUser($user->id);
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_deleteUser_throws_exception_when_user_not_found(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->repository()->deleteUser(999999);
+    }
 }

--- a/src/app/Packages/Domains/UserRepository.php
+++ b/src/app/Packages/Domains/UserRepository.php
@@ -66,4 +66,15 @@ class UserRepository implements UserRepositroyInterface
 
         return UserDtoFactory::build($user->toArray());
     }
+
+    public function deleteUser(int $id): void
+    {
+        $user = $this->userModel->find($id);
+
+        if ($user === null) {
+            throw new Exception('User not found.');
+        }
+
+        $user->delete();
+    }
 }

--- a/src/app/Packages/Features/CommandUseCases/UseCase/User/DeleteUserUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/User/DeleteUserUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCase\User;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+
+final class DeleteUserUseCase
+{
+    public function __construct(
+        private readonly UserRepositroyInterface $userRepository,
+    ) {}
+
+    public function handle(int $id): void
+    {
+        $this->userRepository->deleteUser($id);
+    }
+}

--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -5,6 +5,7 @@ namespace App\Packages\Features\Controller;
 use App\Http\Controllers\Controller;
 use App\Packages\Features\QueryUseCases\Factory\ViewModel\UserViewModelFactory;
 use App\Packages\Features\CommandUseCases\UseCase\User\CreateUserUseCase;
+use App\Packages\Features\CommandUseCases\UseCase\User\DeleteUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCase\User\UpdateUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCommand\User\CreateUserCommand;
 use App\Packages\Features\CommandUseCases\UseCommand\User\UpdateUserCommand;
@@ -70,6 +71,36 @@ class UserController extends Controller
             }
 
             Log::error('Failed to update user', [
+                'message' => $exception->getMessage(),
+                'trace'   => $exception->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
+    public function deleteUser(
+        Request $request,
+        DeleteUserUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $useCase->handle((int) $request->route('id'));
+
+            return response()->json([
+                'status' => 'success',
+            ], 200);
+        } catch (\Exception $exception) {
+            if ($exception->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to delete user', [
                 'message' => $exception->getMessage(),
                 'trace'   => $exception->getTraceAsString(),
             ]);

--- a/src/app/Packages/Features/Tests/CommandUseCases/DeleteUserUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/DeleteUserUseCaseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Packages\Features\Tests\CommandUseCases;
+
+use App\Packages\Domains\Interface\UserRepositroyInterface;
+use App\Packages\Features\CommandUseCases\UseCase\User\DeleteUserUseCase;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class DeleteUserUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test_handle_calls_repository_deleteUser_with_given_id(): void
+    {
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('deleteUser')
+            ->once()
+            ->with(1);
+
+        (new DeleteUserUseCase($repository))->handle(1);
+    }
+
+    public function test_handle_propagates_exception_when_user_not_found(): void
+    {
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('deleteUser')
+            ->once()
+            ->with(999999)
+            ->andThrow(new \Exception('User not found.'));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        (new DeleteUserUseCase($repository))->handle(999999);
+    }
+}

--- a/src/app/Packages/Features/Tests/DeleteUserTest.php
+++ b/src/app/Packages/Features/Tests/DeleteUserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class DeleteUserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(array $overrides = []): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    public function test_delete_user_returns_200_when_user_exists(): void
+    {
+        $user = $this->seedUser();
+
+        $response = $this->deleteJson("/api/v1/users/{$user->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['status' => 'success']);
+
+        $this->assertDatabaseMissing('users', ['id' => $user->id]);
+    }
+
+    public function test_delete_user_returns_404_when_user_not_found(): void
+    {
+        $response = $this->deleteJson('/api/v1/users/999999');
+
+        $response->assertStatus(404)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'User not found.',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -12,5 +12,6 @@ Route::prefix('v1')->group(function (): void {
 
     Route::get('/users/{id}', [UserController::class, 'getUserById']);
     Route::patch('/users/{id}', [UserController::class, 'updateUser']);
+    Route::delete('/users/{id}', [UserController::class, 'deleteUser']);
     Route::post('/user/create', [UserController::class, 'createUser']);
 });


### PR DESCRIPTION
## Motivation / 目的

Implement the User Delete API (`DELETE /api/v1/users/{id}`) across all layers as part of #514.

ユーザー削除API（`DELETE /api/v1/users/{id}`）をInfra・Application・Presentation層にわたって実装しました（#514）。

## What I have done / 実施内容

### Infra層 (PR #521)
- `UserRepositroyInterface`: `deleteUser(int $id): void` を追加
- `UserRepository`: `deleteUser` 実装
  - IDでユーザーを検索し、存在しない場合は `Exception('User not found.')` をスロー
  - `delete()` でレコードを削除
- `UserRepositoryTest`: DBインテグレーションテストを2件追加

### Application層 (PR #522)
- `DeleteUserUseCase`: `handle(int $id): void`
  - Command オブジェクト不要（削除に必要なのは ID のみ）
  - `UserRepositroyInterface::deleteUser()` を呼び出し、例外はリポジトリから自動伝播

### Presentation層 (PR #523)
- `UserController::deleteUser()`: route `{id}` を int にキャストして `DeleteUserUseCase` を呼び出す
  - 200 on success
  - 404 when `'User not found.'` exception is thrown
  - 500 on other errors with `Log::error`
- Route: `DELETE /api/v1/users/{id}`

## Test Results / テスト結果

### Infra層
- `test_deleteUser_removes_user_when_exists`
- `test_deleteUser_throws_exception_when_user_not_found`

### Application層
- `test_handle_calls_repository_deleteUser_with_given_id`
- `test_handle_propagates_exception_when_user_not_found`

### Presentation層
- `test_delete_user_returns_200_when_user_exists`
- `test_delete_user_returns_404_when_user_not_found`

Closes #514