### PR TITLE
feat: implement Email ValueObject and findByEmail in Infra layer / Email ValueObjectとfindByEmailのInfra層実装

### DIFF
--- a/src/app/Packages/Domains/User/Factory/UserEntityFactory.php
+++ b/src/app/Packages/Domains/User/Factory/UserEntityFactory.php
@@ -5,6 +5,7 @@ namespace App\Packages\Domains\User\Factory;
 use App\Packages\Domains\User\Factory\SubscriptionFactory;
 use App\Packages\Domains\User\UserEntity;
 use App\Packages\Domains\User\AgeRange;
+use App\Packages\Domains\User\ValueObject\Email;
 
 final class UserEntityFactory
 {
@@ -20,7 +21,7 @@ final class UserEntityFactory
             id: isset($data['id']) ? (int) $data['id'] : null,
             firstName: $data['first_name'],
             lastName: $data['last_name'],
-            email: $data['email'],
+            email: new Email($data['email']),
             ageRange: AgeRange::from($data['age_range']),
             subscription: $subscription,
             passwordHash: $data['password_hash'] ?? null,

--- a/src/app/Packages/Domains/User/Interface/UserRepositroyInterface.php
+++ b/src/app/Packages/Domains/User/Interface/UserRepositroyInterface.php
@@ -4,6 +4,7 @@ namespace App\Packages\Domains\User\Interface;
 
 use App\Packages\Domains\User\UserEntity;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use App\Packages\Domains\User\ValueObject\Email;
 
 interface UserRepositroyInterface
 {
@@ -14,4 +15,6 @@ interface UserRepositroyInterface
     public function updateUser(UserEntity $entity): UserDto;
 
     public function deleteUser(int $id): void;
+
+    public function findByEmail(Email $email): ?UserEntity;
 }

--- a/src/app/Packages/Domains/User/Tests/Factory/UserEntityFactoryTest.php
+++ b/src/app/Packages/Domains/User/Tests/Factory/UserEntityFactoryTest.php
@@ -30,7 +30,7 @@ class UserEntityFactoryTest extends TestCase
         $this->assertSame($data['id'], $entity->getId());
         $this->assertSame($data['first_name'], $entity->getFirstName());
         $this->assertSame($data['last_name'], $entity->getLastName());
-        $this->assertSame($data['email'], $entity->getEmail());
+        $this->assertSame($data['email'], $entity->getEmail()->value());
         $this->assertSame(AgeRange::Teens, $entity->getAgeRange());
         $this->assertTrue($entity->getSubscription()->isFree());
         $this->assertNull($entity->getPasswordHash());

--- a/src/app/Packages/Domains/User/Tests/UserEntityTest.php
+++ b/src/app/Packages/Domains/User/Tests/UserEntityTest.php
@@ -6,6 +6,7 @@ use App\Packages\Domains\User\AgeRange;
 use App\Packages\Domains\User\Subscription\Subscription;
 use App\Packages\Domains\User\Subscription\SubscriptionTier;
 use App\Packages\Domains\User\UserEntity;
+use App\Packages\Domains\User\ValueObject\Email;
 use Faker\Factory as FakerFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -20,7 +21,7 @@ class UserEntityTest extends TestCase
             id:           array_key_exists('id', $overrides) ? $overrides['id'] : $faker->unique()->randomNumber(5),
             firstName:    $overrides['first_name']    ?? $faker->firstName(),
             lastName:     $overrides['last_name']     ?? $faker->lastName(),
-            email:        $overrides['email']         ?? $faker->unique()->safeEmail(),
+            email:        isset($overrides['email']) ? new Email($overrides['email']) : new Email($faker->unique()->safeEmail()),
             ageRange:     $overrides['age_range']     ?? AgeRange::Twenties,
             subscription: $overrides['subscription']  ?? $subscription,
             passwordHash: $overrides['password_hash'] ?? null,
@@ -60,7 +61,7 @@ class UserEntityTest extends TestCase
     public function test_getEmail_returns_correct_value(): void
     {
         $entity = $this->buildEntity(['email' => 'john@example.com']);
-        $this->assertSame('john@example.com', $entity->getEmail());
+        $this->assertSame('john@example.com', $entity->getEmail()->value());
     }
 
     public function test_getAgeRange_returns_correct_enum(): void

--- a/src/app/Packages/Domains/User/Tests/UserRepositoryTest.php
+++ b/src/app/Packages/Domains/User/Tests/UserRepositoryTest.php
@@ -9,6 +9,7 @@ use App\Packages\Domains\User\Subscription\Subscription;
 use App\Packages\Domains\User\Subscription\SubscriptionTier;
 use App\Packages\Domains\User\UserEntity;
 use App\Packages\Domains\User\UserRepository;
+use App\Packages\Domains\User\ValueObject\Email;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 use Faker\Factory as FakerFactory;
 use Illuminate\Support\Facades\DB;
@@ -138,4 +139,38 @@ class UserRepositoryTest extends TestCase
 
         $this->repository()->deleteUser(999999);
     }
+
+    public function test_findByEmail_returns_user_entity_when_user_exists(): void
+    {
+        $user = $this->seedUser(['email' => 'john@example.com']);
+
+        $result = $this->repository()->findByEmail(new Email('john@example.com'));
+
+        $this->assertInstanceOf(UserEntity::class, $result);
+        $this->assertSame($user->email, $result->getEmail()->value());
+        $this->assertSame($user->first_name, $result->getFirstName());
+        $this->assertSame($user->last_name, $result->getLastName());
+    }
+
+    public function test_findByEmail_returns_null_when_user_does_not_exist(): void
+    {
+        $result = $this->repository()->findByEmail(new Email('notfound@example.com'));
+
+        $this->assertNull($result);
+    }
+
+    public function test_findByEmail_returns_correct_password_hash(): void
+    {
+        $plainPassword = 'secret123';
+        $this->seedUser([
+            'email'    => 'hash@example.com',
+            'password' => bcrypt($plainPassword),
+        ]);
+
+        $result = $this->repository()->findByEmail(new Email('hash@example.com'));
+
+        $this->assertNotNull($result->getPasswordHash());
+        $this->assertTrue(password_verify($plainPassword, $result->getPasswordHash()));
+    }
+
 }

--- a/src/app/Packages/Domains/User/UserEntity.php
+++ b/src/app/Packages/Domains/User/UserEntity.php
@@ -3,6 +3,7 @@
 namespace App\Packages\Domains\User;
 
 use App\Packages\Domains\User\Subscription\Subscription;
+use App\Packages\Domains\User\ValueObject\Email;
 
 final readonly class UserEntity
 {
@@ -10,7 +11,7 @@ final readonly class UserEntity
         private readonly ?int $id,
         private readonly string $firstName,
         private readonly string $lastName,
-        private readonly string $email,
+        private readonly Email $email,
         private readonly AgeRange $ageRange,
         private readonly Subscription $subscription,
         private readonly ?string $passwordHash = null,
@@ -41,7 +42,7 @@ final readonly class UserEntity
         return $this->firstName . ' ' . $this->lastName;
     }
 
-    public function getEmail(): string
+    public function getEmail(): Email
     {
         return $this->email;
     }

--- a/src/app/Packages/Domains/User/UserRepository.php
+++ b/src/app/Packages/Domains/User/UserRepository.php
@@ -5,6 +5,8 @@ namespace App\Packages\Domains\User;
 use App\Models\User;
 use App\Packages\Domains\User\Interface\UserRepositroyInterface;
 use App\Packages\Domains\User\UserEntity;
+use App\Packages\Domains\User\ValueObject\Email;
+use App\Packages\Domains\User\Factory\UserEntityFactory;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
 use App\Packages\Features\QueryUseCases\Factory\Dto\UserDtoFactory;
 use Exception;
@@ -18,7 +20,7 @@ class UserRepository implements UserRepositroyInterface
     public function createUser(UserEntity $entity): UserDto
     {
         $insertUser = $this->userModel->create([
-            'email'                   => $entity->getEmail(),
+            'email'                   => $entity->getEmail()->value(),
             'first_name'              => $entity->getFirstName(),
             'last_name'               => $entity->getLastName(),
             'password'                => $entity->getPasswordHash(),
@@ -56,7 +58,7 @@ class UserRepository implements UserRepositroyInterface
         $user->update([
             'first_name'              => $entity->getFirstName(),
             'last_name'               => $entity->getLastName(),
-            'email'                   => $entity->getEmail(),
+            'email'                   => $entity->getEmail()->value(),
             'age_range'               => $entity->getAgeRange()->value,
             'subscription_tier'       => $entity->getSubscription()->getTier()->value,
             'subscription_expires_at' => $entity->getSubscription()->getExpiresAt()?->format('Y-m-d H:i:s'),
@@ -76,5 +78,25 @@ class UserRepository implements UserRepositroyInterface
         }
 
         $user->delete();
+    }
+
+    public function findByEmail(Email $email): ?UserEntity
+    {
+        $user = $this->userModel->where('email', $email->value())->first();
+
+        if ($user === null) {
+            return null;
+        }
+
+        return UserEntityFactory::build([
+            'id'                      => $user->id,
+            'first_name'              => $user->first_name,
+            'last_name'               => $user->last_name,
+            'email'                   => $user->email,
+            'age_range'               => $user->age_range,
+            'subscription_tier'       => $user->subscription_tier,
+            'subscription_expires_at' => $user->subscription_expires_at,
+            'password_hash'           => $user->password,
+        ]);
     }
 }

--- a/src/app/Packages/Domains/User/ValueObject/Email.php
+++ b/src/app/Packages/Domains/User/ValueObject/Email.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Packages\Domains\User\ValueObject;
+
+use InvalidArgumentException;
+
+final class Email
+{
+    public function __construct(private readonly string $value)
+    {
+        if (!filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidArgumentException('Invalid email format');
+        }
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function isEqual(self $otherEmail): bool
+    {
+        return $this->value === $otherEmail->value;
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Implement the Email ValueObject and `findByEmail` repository method as part of the User Login API (#405).

ユーザーログインAPI（#405）のInfra層として、Email ValueObjectと `findByEmail` を実装しました。

## What I have done / 実施内容

- `Email.php`: Email ValueObject を追加
- `UserRepositroyInterface`: `findByEmail(Email $email): ?UserEntity` を追加
- `UserEntityFactory`: `email` のメンバー変数を `new Email(...)` 経由で構築するよう更新
- `UserEntity`: `getEmail()` の戻り値を `string` → `Email` VO に変更
- `UserRepository`: `findByEmail` 実装、`getEmail()->value()` によるDB操作に対応

## Test Results / テスト結果

Integration tests hitting the real DB:

- `test_findByEmail_returns_user_entity_when_user_exists`
- `test_findByEmail_returns_null_when_user_does_not_exist`
- `test_findByEmail_returns_correct_password_hash`

Closes #527