### PR TITLE
feat: implement SanctumTokenService for token issuance and revocation / Sanctumトークン発行・失効のInfra層実装

### DIFF
--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
+    use HasApiTokens;
     protected $table = 'users';
 
     protected $fillable = [

--- a/src/app/Packages/Domains/User/Interface/TokenServiceInterface.php
+++ b/src/app/Packages/Domains/User/Interface/TokenServiceInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Packages\Domains\User\Interface;
+
+use App\Packages\Domains\User\UserEntity;
+
+interface TokenServiceInterface
+{
+    public function createToken(UserEntity $entity): string;
+
+    public function revokeAllTokens(UserEntity $entity): void;
+}

--- a/src/app/Packages/Domains/User/Service/SanctumTokenService.php
+++ b/src/app/Packages/Domains/User/Service/SanctumTokenService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Packages\Domains\User\Service;
+
+use App\Models\User;
+use App\Packages\Domains\User\Interface\TokenServiceInterface;
+use App\Packages\Domains\User\UserEntity;
+use RuntimeException;
+
+class SanctumTokenService implements TokenServiceInterface
+{
+    public function createToken(UserEntity $entity): string
+    {
+        $user = User::find($entity->getId());
+
+        if ($user === null) {
+            throw new RuntimeException('User not found.');
+        }
+
+        return $user->createToken('auth-token')->plainTextToken;
+    }
+
+    public function revokeAllTokens(UserEntity $entity): void
+    {
+        $user = User::find($entity->getId());
+
+        if ($user === null) {
+            throw new RuntimeException('User not found.');
+        }
+
+        $user->tokens()->delete();
+    }
+}

--- a/src/app/Packages/Domains/User/Tests/Service/SanctumTokenServiceTest.php
+++ b/src/app/Packages/Domains/User/Tests/Service/SanctumTokenServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Packages\Domains\User\Tests\Service;
+
+use App\Models\User;
+use App\Packages\Domains\User\Factory\UserEntityFactory;
+use App\Packages\Domains\User\Service\SanctumTokenService;
+use App\Packages\Domains\User\UserEntity;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SanctumTokenServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            DB::connection('mysql')->table('personal_access_tokens')->truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function service(): SanctumTokenService
+    {
+        return new SanctumTokenService();
+    }
+
+    private function seedUser(array $overrides = []): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create(array_merge([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ], $overrides));
+    }
+
+    private function buildEntityFromUser(User $user): UserEntity
+    {
+        return UserEntityFactory::build([
+            'id'                      => $user->id,
+            'first_name'              => $user->first_name,
+            'last_name'               => $user->last_name,
+            'email'                   => $user->email,
+            'age_range'               => $user->age_range,
+            'subscription_tier'       => $user->subscription_tier,
+            'subscription_expires_at' => $user->subscription_expires_at,
+            'password_hash'           => $user->password,
+        ]);
+    }
+
+    public function test_createToken_returns_plain_text_token(): void
+    {
+        $user   = $this->seedUser();
+        $entity = $this->buildEntityFromUser($user);
+
+        $token = $this->service()->createToken($entity);
+
+        $this->assertIsString($token);
+        $this->assertNotEmpty($token);
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id'   => $user->id,
+            'tokenable_type' => User::class,
+        ]);
+    }
+
+    public function test_createToken_throws_when_user_not_found(): void
+    {
+        $entity = UserEntityFactory::build([
+            'id'                      => 999999,
+            'first_name'              => 'Ghost',
+            'last_name'               => 'User',
+            'email'                   => 'ghost@example.com',
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->service()->createToken($entity);
+    }
+
+    public function test_revokeAllTokens_deletes_tokens_for_user(): void
+    {
+        $user   = $this->seedUser();
+        $entity = $this->buildEntityFromUser($user);
+
+        $user->createToken('token-1');
+        $user->createToken('token-2');
+
+        $this->service()->revokeAllTokens($entity);
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+    }
+
+    public function test_revokeAllTokens_throws_when_user_not_found(): void
+    {
+        $entity = UserEntityFactory::build([
+            'id'                      => 999999,
+            'first_name'              => 'Ghost',
+            'last_name'               => 'User',
+            'email'                   => 'ghost@example.com',
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->service()->revokeAllTokens($entity);
+    }
+}

--- a/src/app/Providers/AppServiceProvider.php
+++ b/src/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Algolia\AlgoliaSearch\Api\SearchClient;
+use App\Packages\Domains\User\Interface\TokenServiceInterface;
+use App\Packages\Domains\User\Service\SanctumTokenService;
 use App\Packages\Domains\WorldHeritage\Adapter\AlgoliaWorldHeritageSearchAdapter;
 use App\Packages\Domains\WorldHeritage\Ports\WorldHeritageSearchPort;
 use Google\Cloud\Storage\StorageClient;
@@ -22,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
     {
         // We bind via a factory closure (instead of a simple class binding) because:
         // - The adapter needs runtime configuration (Algolia app id / API key / index name)
+        $this->app->bind(TokenServiceInterface::class, SanctumTokenService::class);
+
         $this->app->bind(WorldHeritageSearchPort::class, function () {
             $client = SearchClient::create(config('algolia.algolia_app_id'), config('algolia.algolia_search_api_key'));
 

--- a/src/composer.json
+++ b/src/composer.json
@@ -12,6 +12,7 @@
         "algolia/algoliasearch-client-php": "^4.0",
         "google/cloud-storage": "^1",
         "laravel/framework": "^11.31",
+        "laravel/sanctum": "^4.3",
         "laravel/tinker": "^2.9",
         "league/flysystem-google-cloud-storage": "^3",
         "symfony/intl": "^7.4"

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68110e920a7d7e2ac88297daac555d38",
+    "content-hash": "3720ffca039e682d60884862ba8486cd",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -1934,6 +1934,69 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.13"
             },
             "time": "2026-02-06T12:17:10+00:00"
+        },
+        {
+            "name": "laravel/sanctum",
+            "version": "v4.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sanctum.git",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sanctum/zipball/2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "reference": "2a9bccc18e9907808e0018dd15fa643937886b1e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/database": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^9.15|^10.8|^11.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sanctum\\SanctumServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sanctum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Sanctum provides a featherweight authentication system for SPAs and simple APIs.",
+            "keywords": [
+                "auth",
+                "laravel",
+                "sanctum"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sanctum/issues",
+                "source": "https://github.com/laravel/sanctum"
+            },
+            "time": "2026-04-30T11:46:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/src/config/sanctum.php
+++ b/src/config/sanctum.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
+use Laravel\Sanctum\Sanctum;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stateful Domains
+    |--------------------------------------------------------------------------
+    |
+    | Requests from the following domains / hosts will receive stateful API
+    | authentication cookies. Typically, these should include your local
+    | and production domains which access your API via a frontend SPA.
+    |
+    */
+
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+        '%s%s',
+        'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        Sanctum::currentApplicationUrlWithPort(),
+        // Sanctum::currentRequestHost(),
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Guards
+    |--------------------------------------------------------------------------
+    |
+    | This array contains the authentication guards that will be checked when
+    | Sanctum is trying to authenticate a request. If none of these guards
+    | are able to authenticate the request, Sanctum will use the bearer
+    | token that's present on an incoming request for authentication.
+    |
+    */
+
+    'guard' => ['web'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until an issued token will be
+    | considered expired. This will override any values set in the token's
+    | "expires_at" attribute, but first-party sessions are not affected.
+    |
+    */
+
+    'expiration' => 1440,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Token Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Sanctum can prefix new tokens in order to take advantage of numerous
+    | security scanning initiatives maintained by open source platforms
+    | that notify developers if they commit tokens into repositories.
+    |
+    | See: https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning
+    |
+    */
+
+    'token_prefix' => env('SANCTUM_TOKEN_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sanctum Middleware
+    |--------------------------------------------------------------------------
+    |
+    | When authenticating your first-party SPA with Sanctum you may need to
+    | customize some of the middleware Sanctum uses while processing the
+    | request. You may change the middleware listed below as required.
+    |
+    */
+
+    'middleware' => [
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'validate_csrf_token' => ValidateCsrfToken::class,
+    ],
+
+];

--- a/src/database/migrations/2026_07_13_091936_create_personal_access_tokens_table.php
+++ b/src/database/migrations/2026_07_13_091936_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};


### PR DESCRIPTION
## Motivation / 目的

Implement the token management infrastructure as part of the User Login API (#405).

ユーザーログインAPI（#405）のInfra層として、Sanctumを用いたトークン発行・失効機能を実装しました。

## What I have done / 実施内容

- `laravel/sanctum` をインストール
- `personal_access_tokens` マイグレーションを追加
- `User` モデルに `HasApiTokens` トレイトを追加
- `TokenServiceInterface`: `createToken` / `revokeAllTokens` の2メソッドを定義
- `SanctumTokenService`: Sanctumを使ったトークン発行・失効の実装
- `AppServiceProvider`: `TokenServiceInterface` → `SanctumTokenService` のバインド登録
- `config/sanctum.php`: トークン有効期限を1日（1440分）に設定

## Test Results / テスト結果

Integration tests hitting the real DB:

- `test_createToken_returns_plain_text_token`
- `test_createToken_throws_when_user_not_found`
- `test_revokeAllTokens_deletes_tokens_for_user`
- `test_revokeAllTokens_throws_when_user_not_found`

Closes #532