### PR TITLE
feat: implement Infrastructure layer for User Logout / ユーザーログアウトのInfrastructure層実装

### DIFF
--- a/src/app/Packages/Domains/User/Interface/TokenServiceInterface.php
+++ b/src/app/Packages/Domains/User/Interface/TokenServiceInterface.php
@@ -9,4 +9,6 @@ interface TokenServiceInterface
     public function createToken(UserEntity $entity): string;
 
     public function revokeAllTokens(UserEntity $entity): void;
+
+    public function revokeCurrentToken(string $plainTextToken): void;
 }

--- a/src/app/Packages/Domains/User/Service/SanctumTokenService.php
+++ b/src/app/Packages/Domains/User/Service/SanctumTokenService.php
@@ -5,6 +5,7 @@ namespace App\Packages\Domains\User\Service;
 use App\Models\User;
 use App\Packages\Domains\User\Interface\TokenServiceInterface;
 use App\Packages\Domains\User\UserEntity;
+use Laravel\Sanctum\PersonalAccessToken;
 use RuntimeException;
 
 class SanctumTokenService implements TokenServiceInterface
@@ -29,5 +30,16 @@ class SanctumTokenService implements TokenServiceInterface
         }
 
         $user->tokens()->delete();
+    }
+
+    // Logout lives here rather than in UserRepository because it operates on personal_access_tokens,
+    // not on user data. No user lookup is needed — the plain-text token alone identifies the session to end.
+    public function revokeCurrentToken(string $plainTextToken): void
+    {
+        $token = PersonalAccessToken::findToken($plainTextToken);
+
+        if ($token !== null) {
+            $token->delete();
+        }
     }
 }

--- a/src/app/Packages/Domains/User/Tests/Service/SanctumTokenServiceTest.php
+++ b/src/app/Packages/Domains/User/Tests/Service/SanctumTokenServiceTest.php
@@ -133,4 +133,26 @@ class SanctumTokenServiceTest extends TestCase
 
         $this->service()->revokeAllTokens($entity);
     }
+
+    public function test_revokeCurrentToken_deletes_the_given_token(): void
+    {
+        $user      = $this->seedUser();
+        $plainText = $user->createToken('auth-token')->plainTextToken;
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+
+        $this->service()->revokeCurrentToken($plainText);
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test_revokeCurrentToken_does_nothing_when_token_not_found(): void
+    {
+        $this->service()->revokeCurrentToken('invalid-token-that-does-not-exist');
+    }
 }


### PR DESCRIPTION
## Motivation / 目的

Add `revokeCurrentToken` to `TokenServiceInterface` and implement it in `SanctumTokenService` to support single-session logout.

Logout operates on `personal_access_tokens`, not on user data, so no changes to `UserRepositroyInterface` are needed — the plain-text token alone identifies the session to end.

ログアウト時に現在のセッションのみを無効化するため、`TokenServiceInterface` に `revokeCurrentToken` を追加し、`SanctumTokenService` に実装しました。
ログアウトは `personal_access_tokens` テーブルのみを操作するため、`UserRepositroyInterface` の変更は不要です。

## What I have done / 実施内容

- `TokenServiceInterface`: `revokeCurrentToken(string $plainTextToken): void` を追加
- `SanctumTokenService`: `PersonalAccessToken::findToken()` でトークンを検索し削除。トークンが存在しない場合は何もしない（冪等）

## Test Results / テスト結果

- `SanctumTokenServiceTest::test_revokeCurrentToken_deletes_the_given_token`
- `SanctumTokenServiceTest::test_revokeCurrentToken_does_nothing_when_token_not_found`

Closes #409