### PR TITLE
feat: implement Application layer for User Logout / ユーザーログアウトのApplication層実装

### DIFF
--- a/src/app/Packages/Features/CommandUseCases/UseCase/User/LogoutUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/User/LogoutUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCase\User;
+
+use App\Packages\Domains\User\Interface\TokenServiceInterface;
+
+class LogoutUseCase
+{
+    public function __construct(
+        private readonly TokenServiceInterface $tokenService,
+    ) {}
+
+    public function handle(string $plainTextToken): void
+    {
+        $this->tokenService->revokeCurrentToken($plainTextToken);
+    }
+}

--- a/src/app/Packages/Features/Tests/CommandUseCases/LogoutUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/LogoutUseCaseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Packages\Features\Tests\CommandUseCases;
+
+use App\Packages\Domains\User\Interface\TokenServiceInterface;
+use App\Packages\Features\CommandUseCases\UseCase\User\LogoutUseCase;
+use Mockery;
+use Mockery\MockInterface;
+use RuntimeException;
+use Tests\TestCase;
+
+class LogoutUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test_handle_revokes_current_token(): void
+    {
+        /** @var TokenServiceInterface|MockInterface $tokenService */
+        $tokenService = Mockery::mock(TokenServiceInterface::class);
+        $tokenService->shouldReceive('revokeCurrentToken')
+            ->once()
+            ->with('plain-text-token');
+
+        (new LogoutUseCase($tokenService))->handle('plain-text-token');
+    }
+
+    public function test_handle_propagates_exception_when_revocation_fails(): void
+    {
+        /** @var TokenServiceInterface|MockInterface $tokenService */
+        $tokenService = Mockery::mock(TokenServiceInterface::class);
+        $tokenService->shouldReceive('revokeCurrentToken')
+            ->once()
+            ->andThrow(new RuntimeException('Revocation failed.'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Revocation failed.');
+
+        (new LogoutUseCase($tokenService))->handle('plain-text-token');
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Implement `LogoutUseCase` to handle token revocation in the Application layer.

ログアウト処理を担う `LogoutUseCase` を Application 層に実装しました。

## What I have done / 実施内容

- `LogoutUseCase`: `handle(string $plainTextToken): void`
  - `TokenServiceInterface::revokeCurrentToken($plainTextToken)` を呼び出す
  - 失敗時は例外をそのまま伝播する
  - Login と同様に Command/Input オブジェクトは作成せず、引数は `string $plainTextToken` のみ

## Test Results / テスト結果

- `LogoutUseCaseTest::test_handle_revokes_current_token`
- `LogoutUseCaseTest::test_handle_propagates_exception_when_revocation_fails`

Closes #410