### PR TITLE
feat: implement Presentation layer for User Logout / ユーザーログアウトのPresentation層実装

### DIFF
--- a/src/app/Packages/Features/Controller/AuthController.php
+++ b/src/app/Packages/Features/Controller/AuthController.php
@@ -4,6 +4,7 @@ namespace App\Packages\Features\Controller;
 
 use App\Http\Controllers\Controller;
 use App\Packages\Features\CommandUseCases\UseCase\User\LoginUseCase;
+use App\Packages\Features\CommandUseCases\UseCase\User\LogoutUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -36,6 +37,27 @@ class AuthController extends Controller
             ], 401);
         } catch (Throwable $throw) {
             Log::error('Failed to login', [
+                'message' => $throw->getMessage(),
+                'trace'   => $throw->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
+    public function logout(Request $request, LogoutUseCase $useCase): JsonResponse
+    {
+        try {
+            $useCase->handle($request->bearerToken() ?? '');
+
+            return response()->json([
+                'status' => 'success',
+            ], 200);
+        } catch (Throwable $throw) {
+            Log::error('Failed to logout', [
                 'message' => $throw->getMessage(),
                 'trace'   => $throw->getTraceAsString(),
             ]);

--- a/src/app/Packages/Features/Tests/LogoutTest.php
+++ b/src/app/Packages/Features/Tests/LogoutTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use App\Packages\Features\CommandUseCases\UseCase\User\LogoutUseCase;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            DB::connection('mysql')->table('personal_access_tokens')->truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(): User
+    {
+        return User::create([
+            'first_name'              => 'John',
+            'last_name'               => 'Doe',
+            'email'                   => 'john@example.com',
+            'password'                => bcrypt('secret123'),
+            'age_range'               => '20s',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+    }
+
+    public function test_logout_returns_200_when_authenticated(): void
+    {
+        $user  = $this->seedUser();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->postJson('/api/v1/user/logout');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['status' => 'success']);
+
+        $this->assertDatabaseMissing('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+        ]);
+    }
+
+    public function test_logout_returns_401_when_unauthenticated(): void
+    {
+        $response = $this->postJson('/api/v1/user/logout');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_logout_returns_500_on_unexpected_error(): void
+    {
+        $user  = $this->seedUser();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        $this->mock(LogoutUseCase::class)
+            ->shouldReceive('handle')
+            ->andThrow(new RuntimeException('Unexpected error'));
+
+        $response = $this->withToken($token)
+            ->postJson('/api/v1/user/logout');
+
+        $response->assertStatus(500)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -14,7 +14,11 @@ Route::prefix('v1')->group(function (): void {
     });
 
     Route::post('/user/create', [UserController::class, 'createUser']);
-    Route::post('/user/login', [AuthController::class, 'login']);
+
+    Route::controller(AuthController::class)->prefix('user')->group(function (): void {
+        Route::post('/login', 'login');
+        Route::post('/logout', 'logout')->middleware('auth:sanctum');
+    });
 
     Route::controller(UserController::class)->prefix('users')->group(function (): void {
         Route::get('/{id}', 'getUserById');


### PR DESCRIPTION
## Motivation / 目的

Implement the Presentation layer for `POST /api/v1/user/logout` to complete the User Logout API.

ユーザーログアウトAPI（`POST /api/v1/user/logout`）のPresentation層を実装し、ログアウト機能を完成させました。

## What I have done / 実施内容

- `AuthController`: `logout` アクションを追加
  - `$request->bearerToken()` で現在のトークンを取得し `LogoutUseCase::handle()` に渡す
  - 200: ログアウト成功
  - 401: 未認証（`auth:sanctum` ミドルウェアが処理）
  - 500: その他エラー（`Log::error`）
- `routes/api.php`: `POST /v1/user/logout` を `auth:sanctum` ミドルウェア付きで登録
  - login / logout を `Route::controller(AuthController::class)->prefix('user')` にまとめて整理

## Test Results / テスト結果

- `LogoutTest::test_logout_returns_200_when_authenticated`
- `LogoutTest::test_logout_returns_401_when_unauthenticated`
- `LogoutTest::test_logout_returns_500_on_unexpected_error`

Closes #411