### PR TITLE
fix: enable CORS credentials and externalize frontend origin for Sanctum SPA auth

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
 APP_URL=http://localhost
+FRONTEND_URL=http://localhost:3876
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -12,5 +12,5 @@ return [
     'allowed_headers' => ['*'],
     'exposed_headers' => [],
     'max_age' => 0,
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 ];

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -4,8 +4,7 @@ return [
     'paths' => ['api/*', 'sanctum/csrf-cookie'],
     'allowed_methods' => ['*'],
     'allowed_origins' => [
-        'http://localhost:3876',
-        'http://127.0.0.1:5173',
+        env('FRONTEND_URL', 'http://localhost:3876'),
         'https://zigzagdev.github.io',
     ],
     'allowed_origins_patterns' => [],

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -12,5 +12,11 @@ return [
     'allowed_headers' => ['*'],
     'exposed_headers' => [],
     'max_age' => 0,
+
+    // Sanctum's cookie-based SPA auth sends requests with `credentials: 'include'`.
+    // If this is false, the browser will discard the session cookie on cross-origin
+    // responses even though the cookie itself was issued successfully, so the
+    // frontend appears logged in but authenticated requests (e.g. fetching the
+    // current user) fail silently.
     'supports_credentials' => true,
 ];


### PR DESCRIPTION
## Motivation

Investigating the reported bug "user mypage does not display after login" found two issues in the CORS/Sanctum configuration:

1. `config/cors.php` had `supports_credentials` set to `false`. Sanctum's cookie-based SPA auth requires the frontend to send requests with `credentials: 'include'`, and the browser only forwards/accepts the session cookie cross-origin if the server responds with `Access-Control-Allow-Credentials: true`. With it `false`, login appeared to succeed (the cookie was issued) but subsequent authenticated requests (e.g. fetching the current user for mypage) were silently blocked by the browser.
2. The frontend origin was hardcoded in `allowed_origins` (`http://localhost:3876`, plus a stale `http://127.0.0.1:5173` entry left over from Vite's default port), which drifted from the actual frontend dev port and from the frontend's own `VITE_API_BASE_URL` env-based configuration.

Closes #540

## What I have done

- Set `supports_credentials` to `true` in `config/cors.php` and added a comment explaining why it's required for Sanctum cookie auth
- Replaced the hardcoded frontend origins in `allowed_origins` with `env('FRONTEND_URL', 'http://localhost:3876')`
- Added `FRONTEND_URL` to `.env.example` (and local `.env`, not committed) so both frontend and backend reference the same configurable origin

## Test Results

- Verified via `docker exec heritage-app php artisan tinker --execute="print_r(config('cors'));"` that `allowed_origins` resolves to `['http://localhost:3876', 'https://zigzagdev.github.io']` and `supports_credentials` is `true` (`1`)