### PR TITLE
feat: add GET /api/v1/user/me endpoint / ログイン中ユーザー取得APIの追加

### DIFF
--- a/src/app/Packages/Features/Controller/AuthController.php
+++ b/src/app/Packages/Features/Controller/AuthController.php
@@ -5,6 +5,8 @@ namespace App\Packages\Features\Controller;
 use App\Http\Controllers\Controller;
 use App\Packages\Features\CommandUseCases\UseCase\User\LoginUseCase;
 use App\Packages\Features\CommandUseCases\UseCase\User\LogoutUseCase;
+use App\Packages\Features\QueryUseCases\Factory\ViewModel\UserViewModelFactory;
+use App\Packages\Features\QueryUseCases\UseCase\User\GetUserByIdUseCase;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -58,6 +60,35 @@ class AuthController extends Controller
             ], 200);
         } catch (Throwable $throw) {
             Log::error('Failed to logout', [
+                'message' => $throw->getMessage(),
+                'trace'   => $throw->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+
+    public function me(Request $request, GetUserByIdUseCase $useCase): JsonResponse
+    {
+        try {
+            $dto = $useCase->handle($request->user()->id);
+
+            return response()->json([
+                'status' => 'success',
+                'data'   => UserViewModelFactory::build($dto)->toArray(),
+            ], 200);
+        } catch (Throwable $throw) {
+            if ($throw->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to get current user', [
                 'message' => $throw->getMessage(),
                 'trace'   => $throw->getTraceAsString(),
             ]);

--- a/src/app/Packages/Features/Tests/MeTest.php
+++ b/src/app/Packages/Features/Tests/MeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use App\Packages\Domains\User\Interface\UserRepositroyInterface;
+use App\Packages\Features\QueryUseCases\UseCase\User\GetUserByIdUseCase;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class MeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            DB::connection('mysql')->table('personal_access_tokens')->truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(): User
+    {
+        return User::create([
+            'first_name'              => 'John',
+            'last_name'               => 'Doe',
+            'email'                   => 'john@example.com',
+            'password'                => bcrypt('secret123'),
+            'age_range'               => '20s',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+    }
+
+    public function test_me_returns_200_with_authenticated_user_when_authenticated(): void
+    {
+        $user  = $this->seedUser();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->getJson('/api/v1/user/me');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment([
+                'status' => 'success',
+                'data'   => [
+                    'id'                      => $user->id,
+                    'first_name'              => 'John',
+                    'last_name'               => 'Doe',
+                    'email'                   => 'john@example.com',
+                    'age_range'               => '20s',
+                    'subscription_tier'       => 'free',
+                    'subscription_expires_at' => null,
+                ],
+            ]);
+    }
+
+    public function test_me_returns_401_when_unauthenticated(): void
+    {
+        $response = $this->getJson('/api/v1/user/me');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_me_returns_500_on_unexpected_error(): void
+    {
+        $user  = $this->seedUser();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->andThrow(new RuntimeException('Unexpected error'));
+
+        $this->app->instance(GetUserByIdUseCase::class, new GetUserByIdUseCase($repository));
+
+        $response = $this->withToken($token)
+            ->getJson('/api/v1/user/me');
+
+        $response->assertStatus(500)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -18,6 +18,7 @@ Route::prefix('v1')->group(function (): void {
     Route::controller(AuthController::class)->prefix('user')->group(function (): void {
         Route::post('/login', 'login');
         Route::post('/logout', 'logout')->middleware('auth:sanctum');
+        Route::get('/me', 'me')->middleware('auth:sanctum');
     });
 
     Route::controller(UserController::class)->prefix('users')->group(function (): void {


### PR DESCRIPTION
## Motivation / 目的

`AuthController::login` のレスポンスはトークンのみでユーザーのidを返さないため、フロントエンドはログイン後に「自分自身」の情報を取得する手段を持っていなかった。これがマイページ表示ができない一因だった (#542)。

The login response only returns a token, never the user's id, so the frontend had no way to fetch "its own" user data after logging in. This was one of the causes preventing mypage from displaying (#542).

Closes #542

## What I have done / 実施内容

- `routes/api.php` に `GET /v1/user/me` を `auth:sanctum` ミドルウェア付きで追加
- `AuthController::me` を追加し、Sanctumが認証済みリクエストから解決したユーザーのidを既存の `GetUserByIdUseCase` に渡して結果を返す
- Domain層・Infra層は既存の `findById` を、Application層は既存の `GetUserByIdUseCase` をそのまま再利用（変更なし）。今回の変更はPresentation層のみ (#543)

## Test Results / テスト結果

- `test_me_returns_200_with_authenticated_user_when_authenticated`
- `test_me_returns_401_when_unauthenticated`
- `test_me_returns_500_on_unexpected_error`
- 既存の `LoginTest` / `LogoutTest` の回帰なしを確認済み