### PR TITLE
fix: include frontend origin in SANCTUM_STATEFUL_DOMAINS / Sanctumのstateful対象にフロントのオリジンを追加

### DIFF
--- a/src/config/sanctum.php
+++ b/src/config/sanctum.php
@@ -5,6 +5,15 @@ use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
+$frontendUrl  = env('FRONTEND_URL', 'http://localhost:3876');
+$frontendHost = parse_url($frontendUrl, PHP_URL_HOST);
+$frontendPort = parse_url($frontendUrl, PHP_URL_PORT);
+
+// Sanctum only treats requests from a listed domain/host as cookie-based SPA
+// requests; anything else falls back to requiring a bearer token. The frontend
+// (FRONTEND_URL) must be listed here or its session cookie is never checked.
+$frontendStatefulDomain = $frontendPort ? "{$frontendHost}:{$frontendPort}" : $frontendHost;
+
 return [
 
     /*
@@ -19,8 +28,9 @@ return [
     */
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
-        '%s%s',
+        '%s,%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        $frontendStatefulDomain,
         Sanctum::currentApplicationUrlWithPort(),
         // Sanctum::currentRequestHost(),
     ))),


### PR DESCRIPTION
## Motivation / 目的

Fixing CORS `supports_credentials` alone is not enough for the frontend's cookie-based Sanctum auth to work. Sanctum's `EnsureFrontendRequestsAreStateful` middleware only treats a request as session/cookie-based if its origin is listed in `config('sanctum.stateful')`. The frontend's `localhost:3876` was missing from that list, so requests from it were never routed through the session guard and instead fell back to bearer-token authentication — which the frontend never sends (it is fully cookie-based, confirmed in `src/app/features/auth/apis/auth-api.ts`). This caused authenticated requests to fail with 401 even after the CORS fix.

CORSの `supports_credentials` を直すだけでは、Cookieベースのフロントで認証は動きません。SanctumのミドルウェアはリクエストのOriginが `config('sanctum.stateful')` に載っている場合のみセッション（Cookie）方式で認証し、載っていない場合はBearerトークン方式にフォールバックします。フロントの `localhost:3876` がこの一覧に無かったため、CORS修正後も401のままでした。

## What I have done / 実施内容

- `config/sanctum.php` の `stateful` に、既存の `FRONTEND_URL` 環境変数からホスト:ポートを導出して追加
- 新しい環境変数は増やさず、CORS修正で導入済みの `FRONTEND_URL` を再利用

## Test Results / テスト結果

- `docker exec heritage-app php artisan tinker --execute="print_r(config('sanctum.stateful'));"` で `localhost:3876` が一覧に含まれることを確認
- 既存の `LoginTest` / `LogoutTest` の回帰なしを確認済み