### PR TITLE
fix: enable Sanctum SPA cookie auth for the frontend origin / フロントのオリジンに対するSanctum Cookie認証の有効化

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -4,6 +4,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
 APP_URL=http://localhost
+FRONTEND_URL=http://localhost:3876
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -12,5 +12,5 @@ return [
     'allowed_headers' => ['*'],
     'exposed_headers' => [],
     'max_age' => 0,
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 ];

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -4,8 +4,7 @@ return [
     'paths' => ['api/*', 'sanctum/csrf-cookie'],
     'allowed_methods' => ['*'],
     'allowed_origins' => [
-        'http://localhost:3876',
-        'http://127.0.0.1:5173',
+        env('FRONTEND_URL', 'http://localhost:3876'),
         'https://zigzagdev.github.io',
     ],
     'allowed_origins_patterns' => [],

--- a/src/config/cors.php
+++ b/src/config/cors.php
@@ -12,5 +12,11 @@ return [
     'allowed_headers' => ['*'],
     'exposed_headers' => [],
     'max_age' => 0,
+
+    // Sanctum's cookie-based SPA auth sends requests with `credentials: 'include'`.
+    // If this is false, the browser will discard the session cookie on cross-origin
+    // responses even though the cookie itself was issued successfully, so the
+    // frontend appears logged in but authenticated requests (e.g. fetching the
+    // current user) fail silently.
     'supports_credentials' => true,
 ];

--- a/src/config/sanctum.php
+++ b/src/config/sanctum.php
@@ -5,6 +5,15 @@ use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
+$frontendUrl  = env('FRONTEND_URL', 'http://localhost:3876');
+$frontendHost = parse_url($frontendUrl, PHP_URL_HOST);
+$frontendPort = parse_url($frontendUrl, PHP_URL_PORT);
+
+// Sanctum only treats requests from a listed domain/host as cookie-based SPA
+// requests; anything else falls back to requiring a bearer token. The frontend
+// (FRONTEND_URL) must be listed here or its session cookie is never checked.
+$frontendStatefulDomain = $frontendPort ? "{$frontendHost}:{$frontendPort}" : $frontendHost;
+
 return [
 
     /*
@@ -19,8 +28,9 @@ return [
     */
 
     'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
-        '%s%s',
+        '%s,%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
+        $frontendStatefulDomain,
         Sanctum::currentApplicationUrlWithPort(),
         // Sanctum::currentRequestHost(),
     ))),


### PR DESCRIPTION
## Motivation / 目的

Investigating the reported bug "user mypage does not display after login" found that Sanctum's cookie-based SPA authentication was broken in two independent ways:

1. `config/cors.php` had `supports_credentials: false`, so the browser discarded the session cookie on cross-origin responses even though it was issued successfully.
2. Even after fixing that, `config/sanctum.php`'s `stateful` domain list did not include the frontend's origin (`localhost:3876`), so Sanctum never routed its requests through session-based auth and fell back to requiring a bearer token — which the frontend never sends (it is fully cookie-based, confirmed in `src/app/features/auth/apis/auth-api.ts`).

Both had to be fixed together for cookie-based authentication to work end-to-end. See #540 and #542 for the fuller investigation.

Closes #540

## What I have done / 実施内容

- Set `supports_credentials` to `true` in `config/cors.php` (with a comment explaining why Sanctum SPA auth requires it)
- Replaced the hardcoded frontend origins in `allowed_origins` with `env('FRONTEND_URL', 'http://localhost:3876')`
- Added `FRONTEND_URL` to `.env` / `.env.example`
- Added the `FRONTEND_URL` host to `config/sanctum.php`'s `stateful` domains so Sanctum treats the frontend as a stateful (cookie-based) client

## Test Results / テスト結果

- Verified via `docker exec heritage-app php artisan tinker` that `config('cors')` resolves `allowed_origins` to `['http://localhost:3876', 'https://zigzagdev.github.io']` with `supports_credentials` `true`, and `config('sanctum.stateful')` includes `localhost:3876`
- Existing `LoginTest` / `LogoutTest` pass with no regressions