### PR TITLE
fix: support partial updates in PATCH /api/v1/users/{id} / ユーザー更新APIの部分更新対応

### DIFF
--- a/src/app/Packages/Features/CommandUseCases/UseCase/User/UpdateUserUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/User/UpdateUserUseCase.php
@@ -6,6 +6,7 @@ use App\Packages\Domains\User\Interface\UserRepositroyInterface;
 use App\Packages\Domains\User\Factory\UserEntityFactory;
 use App\Packages\Features\CommandUseCases\UseCommand\User\UpdateUserCommand;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Exception;
 
 final class UpdateUserUseCase
 {
@@ -15,14 +16,20 @@ final class UpdateUserUseCase
 
     public function handle(UpdateUserCommand $command): UserDto
     {
+        $existing = $this->userRepository->findById($command->id);
+
+        if ($existing === null) {
+            throw new Exception('User not found.');
+        }
+
         $entity = UserEntityFactory::build([
             'id'                      => $command->id,
-            'first_name'              => $command->firstName,
-            'last_name'               => $command->lastName,
-            'email'                   => $command->email,
-            'age_range'               => $command->ageRange,
-            'subscription_tier'       => $command->subscriptionTier,
-            'subscription_expires_at' => $command->subscriptionExpiresAt,
+            'first_name'              => $command->firstName ?? $existing->firstName,
+            'last_name'               => $command->lastName ?? $existing->lastName,
+            'email'                   => $command->email ?? $existing->email,
+            'age_range'               => $command->ageRange ?? $existing->ageRange,
+            'subscription_tier'       => $command->subscriptionTier ?? $existing->subscriptionTier,
+            'subscription_expires_at' => $command->subscriptionExpiresAt ?? $existing->subscriptionExpiresAt,
         ]);
 
         return $this->userRepository->updateUser($entity);

--- a/src/app/Packages/Features/CommandUseCases/UseCommand/User/UpdateUserCommand.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCommand/User/UpdateUserCommand.php
@@ -6,40 +6,32 @@ use InvalidArgumentException;
 
 final class UpdateUserCommand
 {
-    private const REQUIRED_KEYS = [
-        'id',
-        'first_name',
-        'last_name',
-        'email',
-        'age_range',
-        'subscription_tier',
-    ];
-
     private function __construct(
         public readonly int     $id,
-        public readonly string  $firstName,
-        public readonly string  $lastName,
-        public readonly string  $email,
-        public readonly string  $ageRange,
-        public readonly string  $subscriptionTier,
+        public readonly ?string $firstName,
+        public readonly ?string $lastName,
+        public readonly ?string $email,
+        public readonly ?string $ageRange,
+        public readonly ?string $subscriptionTier,
         public readonly ?string $subscriptionExpiresAt,
     ) {}
 
+    // Fields other than `id` are optional: this supports partial updates,
+    // where an omitted field means "keep the current value" (resolved by
+    // UpdateUserUseCase), rather than requiring the full user payload.
     public static function fromArray(array $data): self
     {
-        foreach (self::REQUIRED_KEYS as $key) {
-            if (!array_key_exists($key, $data)) {
-                throw new InvalidArgumentException("Missing required key: {$key}");
-            }
+        if (!array_key_exists('id', $data)) {
+            throw new InvalidArgumentException('Missing required key: id');
         }
 
         return new self(
             id:                    (int) $data['id'],
-            firstName:             $data['first_name'],
-            lastName:              $data['last_name'],
-            email:                 $data['email'],
-            ageRange:              $data['age_range'],
-            subscriptionTier:      $data['subscription_tier'],
+            firstName:             $data['first_name'] ?? null,
+            lastName:              $data['last_name'] ?? null,
+            email:                 $data['email'] ?? null,
+            ageRange:              $data['age_range'] ?? null,
+            subscriptionTier:      $data['subscription_tier'] ?? null,
             subscriptionExpiresAt: $data['subscription_expires_at'] ?? null,
         );
     }

--- a/src/app/Packages/Features/Controller/UserController.php
+++ b/src/app/Packages/Features/Controller/UserController.php
@@ -62,7 +62,7 @@ class UserController extends Controller
                 'status' => 'success',
                 'data'   => UserViewModelFactory::build($dto)->toArray(),
             ], 200);
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             if ($exception->getMessage() === 'User not found.') {
                 return response()->json([
                     'status'  => 'error',

--- a/src/app/Packages/Features/Tests/CommandUseCases/UpdateUserCommandTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/UpdateUserCommandTest.php
@@ -46,27 +46,41 @@ class UpdateUserCommandTest extends TestCase
         $this->assertSame('2027-01-01 00:00:00', $command->subscriptionExpiresAt);
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('missingKeyProvider')]
-    public function test_fromArray_throws_when_required_key_is_missing(string $missingKey): void
+    public function test_fromArray_throws_when_id_is_missing(): void
     {
         $data = $this->validData();
-        unset($data[$missingKey]);
+        unset($data['id']);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Missing required key: {$missingKey}");
+        $this->expectExceptionMessage('Missing required key: id');
 
         UpdateUserCommand::fromArray($data);
     }
 
-    public static function missingKeyProvider(): array
+    #[\PHPUnit\Framework\Attributes\DataProvider('optionalKeyProvider')]
+    public function test_fromArray_allows_optional_key_to_be_omitted(string $optionalKey): void
+    {
+        $data = $this->validData();
+        unset($data[$optionalKey]);
+
+        $command = UpdateUserCommand::fromArray($data);
+
+        $this->assertNull($command->{$this->toCommandProperty($optionalKey)});
+    }
+
+    public static function optionalKeyProvider(): array
     {
         return [
-            ['id'],
             ['first_name'],
             ['last_name'],
             ['email'],
             ['age_range'],
             ['subscription_tier'],
         ];
+    }
+
+    private function toCommandProperty(string $key): string
+    {
+        return lcfirst(str_replace('_', '', ucwords($key, '_')));
     }
 }

--- a/src/app/Packages/Features/Tests/CommandUseCases/UpdateUserUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/UpdateUserUseCaseTest.php
@@ -7,6 +7,7 @@ use App\Packages\Domains\User\UserEntity;
 use App\Packages\Features\CommandUseCases\UseCase\User\UpdateUserUseCase;
 use App\Packages\Features\CommandUseCases\UseCommand\User\UpdateUserCommand;
 use App\Packages\Features\QueryUseCases\Dto\User\UserDto;
+use Exception;
 use Faker\Factory as FakerFactory;
 use Mockery;
 use Mockery\MockInterface;
@@ -20,26 +21,26 @@ class UpdateUserUseCaseTest extends TestCase
         parent::tearDown();
     }
 
-    private function buildCommand(): UpdateUserCommand
+    private function buildCommand(array $overrides = []): UpdateUserCommand
     {
         $faker = FakerFactory::create();
 
-        return UpdateUserCommand::fromArray([
+        return UpdateUserCommand::fromArray(array_merge([
             'id'                => $faker->unique()->randomNumber(5),
             'first_name'        => $faker->firstName(),
             'last_name'         => $faker->lastName(),
             'email'             => $faker->unique()->safeEmail(),
             'age_range'         => $faker->randomElement(['teens', '20s', '30s', '40s', '50s', '60plus']),
             'subscription_tier' => 'free',
-        ]);
+        ], $overrides));
     }
 
-    private function buildDto(): UserDto
+    private function buildDto(int $id): UserDto
     {
         $faker = FakerFactory::create();
 
         return new UserDto(
-            id:                    $faker->unique()->randomNumber(5),
+            id:                    $id,
             firstName:             $faker->firstName(),
             lastName:              $faker->lastName(),
             email:                 $faker->unique()->safeEmail(),
@@ -52,17 +53,66 @@ class UpdateUserUseCaseTest extends TestCase
     public function test_handle_passes_entity_to_repository_and_returns_dto(): void
     {
         $command = $this->buildCommand();
-        $dto     = $this->buildDto();
+        $existing = $this->buildDto($command->id);
+        $updated  = $this->buildDto($command->id);
 
         /** @var UserRepositroyInterface|MockInterface $repository */
         $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->once()
+            ->with($command->id)
+            ->andReturn($existing);
         $repository->shouldReceive('updateUser')
             ->once()
             ->with(Mockery::type(UserEntity::class))
-            ->andReturn($dto);
+            ->andReturn($updated);
 
         $result = (new UpdateUserUseCase($repository))->handle($command);
 
-        $this->assertSame($dto, $result);
+        $this->assertSame($updated, $result);
+    }
+
+    public function test_handle_keeps_existing_value_when_field_is_omitted(): void
+    {
+        $command  = $this->buildCommand(['first_name' => null]);
+        $existing = $this->buildDto($command->id);
+        $passedEntity = null;
+
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->once()
+            ->with($command->id)
+            ->andReturn($existing);
+        $repository->shouldReceive('updateUser')
+            ->once()
+            ->with(Mockery::on(function (UserEntity $entity) use (&$passedEntity) {
+                $passedEntity = $entity;
+
+                return true;
+            }))
+            ->andReturn($existing);
+
+        (new UpdateUserUseCase($repository))->handle($command);
+
+        $this->assertSame($existing->firstName, $passedEntity->getFirstName());
+    }
+
+    public function test_handle_throws_when_user_not_found(): void
+    {
+        $command = $this->buildCommand();
+
+        /** @var UserRepositroyInterface|MockInterface $repository */
+        $repository = Mockery::mock(UserRepositroyInterface::class);
+        $repository->shouldReceive('findById')
+            ->once()
+            ->with($command->id)
+            ->andReturn(null);
+        $repository->shouldNotReceive('updateUser');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        (new UpdateUserUseCase($repository))->handle($command);
     }
 }

--- a/src/app/Packages/Features/Tests/UpdateUserTest.php
+++ b/src/app/Packages/Features/Tests/UpdateUserTest.php
@@ -95,15 +95,18 @@ class UpdateUserTest extends TestCase
             ]);
     }
 
-    public function test_update_user_returns_500_when_required_key_is_missing(): void
+    public function test_update_user_returns_500_with_json_when_age_range_is_invalid(): void
     {
-        $user    = $this->seedUser();
-        $payload = $this->validPayload();
-        unset($payload['email']);
+        $user = $this->seedUser();
 
-        $response = $this->patchJson("/api/v1/users/{$user->id}", $payload);
+        $response = $this->patchJson("/api/v1/users/{$user->id}", [
+            'age_range' => 'not-a-real-value',
+        ]);
 
         $response->assertStatus(500)
-            ->assertJsonFragment(['status' => 'error']);
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ]);
     }
 }


### PR DESCRIPTION
## Motivation / 目的

`PATCH /api/v1/users/{id}` に一部のフィールドだけを送ると、`UpdateUserCommand::fromArray` がすべての必須キー（`first_name`, `last_name`, `email`, `age_range`, `subscription_tier`）を要求していたため `InvalidArgumentException` が発生していた。この例外は `UserController::updateUser` の汎用 `catch` に落ちて `500 Internal Server Error` として返っていた。

Sending only a subset of fields to `PATCH /api/v1/users/{id}` caused `UpdateUserCommand::fromArray` to throw `InvalidArgumentException`, since it required every field (`first_name`, `last_name`, `email`, `age_range`, `subscription_tier`) to be present. That exception fell through `UserController::updateUser`'s generic catch block and surfaced as a `500 Internal Server Error`.

PATCHの意味的にも部分更新を許可すべきという判断のもと、更新対象フィールドのみ送れば良い設計に変更した。

また、修正の過程で別の問題も見つかった。`UserController::updateUser` は `catch (\Exception)` のみで、`\Error` 系（例: 無効な `age_range` を渡した際に `AgeRange::from()` が投げる `\ValueError`）を一切キャッチできず、生のLaravelデバッグエラーページがそのまま返っていた（`createUser` は既に `\Throwable` をキャッチしており一貫性がなかった）。これも合わせて修正した。

While fixing this, we also found that `UserController::updateUser` only caught `\Exception`, so `\Error`-family exceptions (e.g. the `\ValueError` thrown by `AgeRange::from()` on an invalid `age_range` value) were never caught, leaking Laravel's raw debug error page instead of a clean JSON response (`createUser` already caught `\Throwable`, so this was an inconsistency). Fixed that too.

## What I have done / 実施内容

- `UpdateUserCommand`: `id` 以外の全フィールドを任意（nullable）にし、`fromArray` は `id` の存在のみを必須チェックするように変更
- `UpdateUserUseCase`: `handle()` の冒頭で既存ユーザーを `findById` で取得し、コマンドで指定されなかったフィールドは既存値をそのまま使う（未指定=変更なし）ようにマージするロジックを追加。ユーザーが存在しない場合は従来通り `User not found.` を投げる
- `UserController::updateUser` の `catch (\Exception)` を `catch (\Throwable)` に変更し、`\ValueError` 等でも正しくJSONの `Internal Server Error` を返すように修正
- 既存の `UpdateUserCommandTest` / `UpdateUserUseCaseTest` を部分更新の挙動に合わせて更新
- `UpdateUserTest` の `test_update_user_returns_500_when_required_key_is_missing`（今回の設計変更で前提が崩れた既存テスト）を削除し、代わりに無効な `age_range` を送った際にクリーンなJSON 500が返ることを確認するテストに置き換え

## Test Results / テスト結果

- `UpdateUserCommandTest::test_fromArray_creates_command_with_valid_data`
- `UpdateUserCommandTest::test_fromArray_sets_subscription_expires_at_when_provided`
- `UpdateUserCommandTest::test_fromArray_throws_when_id_is_missing`
- `UpdateUserCommandTest::test_fromArray_allows_optional_key_to_be_omitted`（first_name/last_name/email/age_range/subscription_tier）
- `UpdateUserUseCaseTest::test_handle_passes_entity_to_repository_and_returns_dto`
- `UpdateUserUseCaseTest::test_handle_keeps_existing_value_when_field_is_omitted`
- `UpdateUserUseCaseTest::test_handle_throws_when_user_not_found`
- `UpdateUserTest::test_update_user_returns_200_with_updated_data`
- `UpdateUserTest::test_update_user_returns_404_when_user_not_found`
- `UpdateUserTest::test_update_user_returns_500_with_json_when_age_range_is_invalid`
- 実リクエストで `PATCH /api/v1/users/1` に `first_name` のみ送信し、他フィールドが保持されたまま更新されることを確認
- 既存の `LoginTest` / `LogoutTest` / `MeTest` の回帰なしを確認済み