### PR TITLE
fix: default subscription_tier to free in SubscriptionFactory when omitted / SubscriptionFactoryでsubscription_tier省略時にfreeへデフォルト設定

### DIFF
--- a/src/app/Packages/Domains/User/Factory/SubscriptionFactory.php
+++ b/src/app/Packages/Domains/User/Factory/SubscriptionFactory.php
@@ -21,7 +21,7 @@ final class SubscriptionFactory
         }
 
         return new Subscription(
-            SubscriptionTier::from($data['tier']),
+            SubscriptionTier::from($data['tier'] ?? SubscriptionTier::Free->value),
             $expiresAt,
             $now,
         );

--- a/src/app/Packages/Domains/User/Factory/UserEntityFactory.php
+++ b/src/app/Packages/Domains/User/Factory/UserEntityFactory.php
@@ -12,7 +12,7 @@ final class UserEntityFactory
     public static function build(array $data): UserEntity
     {
         $subscription = SubscriptionFactory::build([
-            'tier' => $data['subscription_tier'],
+            'tier' => $data['subscription_tier'] ?? null,
             'expires_at' => $data['subscription_expires_at'] ?? null,
             'now' => $data['now'] ?? null,
         ]);

--- a/src/app/Packages/Domains/User/Tests/Factory/UserEntityFactoryTest.php
+++ b/src/app/Packages/Domains/User/Tests/Factory/UserEntityFactoryTest.php
@@ -55,6 +55,22 @@ class UserEntityFactoryTest extends TestCase
         $this->assertSame('hashed_value', $entity->getPasswordHash());
     }
 
+    public function test_build_defaults_subscription_tier_to_free_when_omitted(): void
+    {
+        $faker = FakerFactory::create();
+
+        $entity = UserEntityFactory::build([
+            'id'                      => $faker->unique()->randomNumber(5),
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'age_range'               => 'teens',
+            'subscription_expires_at' => null,
+        ]);
+
+        $this->assertTrue($entity->getSubscription()->isFree());
+    }
+
     public function test_build_passes_expires_at_to_subscription(): void
     {
         $faker = FakerFactory::create();


### PR DESCRIPTION
## Motivation / 目的

`subscription_tier` was already made optional at the `CreateUserCommand`/`CreateUserUseCase` level, but the Domain-layer factories (`UserEntityFactory`, `SubscriptionFactory`) still assumed the key was always present and non-null. Any future caller that omitted `subscription_tier` would hit a `TypeError` from `SubscriptionTier::from(null)` instead of getting the intended `free` default.

`subscription_tier`は`CreateUserCommand`/`CreateUserUseCase`側では既に任意項目化されていましたが、Domain層のファクトリ(`UserEntityFactory`, `SubscriptionFactory`)は依然として値が必ず存在する前提でした。将来`subscription_tier`を省略する呼び出しが増えた場合、`SubscriptionTier::from(null)`で`TypeError`になってしまう抜けがありました。

## What I have done / 実施内容

- `SubscriptionFactory::build()`: default the tier to `SubscriptionTier::Free->value` when `$data['tier']` is null
- `UserEntityFactory::build()`: pass `$data['subscription_tier'] ?? null` instead of a direct array access, so a missing key no longer raises an undefined array key warning before reaching `SubscriptionFactory`
- Added test coverage for the default behavior

## Test Results / テスト結果

- `UserEntityFactoryTest::test_build_returns_user_entity_with_correct_values`
- `UserEntityFactoryTest::test_build_sets_password_hash_when_provided`
- `UserEntityFactoryTest::test_build_defaults_subscription_tier_to_free_when_omitted`
- `UserEntityFactoryTest::test_build_passes_expires_at_to_subscription`
- `SubscriptionTest` (all cases)
- `UserEntityTest` (all cases)
- `CreateUserCommandTest` / `CreateUserUseCaseTest` / `UpdateUserCommandTest` / `UpdateUserUseCaseTest` (all cases)

Closes #559