### PR TITLE
feat: add user_favorite migration for favorite heritages join table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+src/.config/

--- a/src/database/migrations/2026_08_01_000000_create_user_favorite_table.php
+++ b/src/database/migrations/2026_08_01_000000_create_user_favorite_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_favorite', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('world_heritage_site_id');
+            $table->timestamps();
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnDelete();
+
+            $table->foreign('world_heritage_site_id')
+                ->references('id')
+                ->on('world_heritage_sites')
+                ->cascadeOnDelete();
+
+            $table->unique(['user_id', 'world_heritage_site_id'], 'user_favorite_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_favorite');
+    }
+};


### PR DESCRIPTION
## Summary
- ユーザーがお気に入り登録した世界遺産を管理するための `user_favorite` 中間テーブルを追加
- `users` / `world_heritage_sites` への外部キー制約（cascadeOnDelete）を設定
- `user_id` + `world_heritage_site_id` の複合ユニーク制約により、同一ユーザー・同一遺産の重複登録を防止

## Changes
- `database/migrations/2026_08_01_000000_create_user_favorite_table.php` を追加
- `.gitignore` に `src/.config/`（psyshのローカルキャッシュ）を追加

## Test plan
- [ ] `php artisan migrate` でマイグレーションが正常に実行されることを確認
- [ ] `php artisan migrate:rollback` でロールバックできることを確認