### PR TITLE
feat: implement Infra layer for user favorites repository / お気に入り機能のInfra層実装

### DIFF
--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Sanctum\HasApiTokens;
 
@@ -32,5 +33,15 @@ class User extends Authenticatable
             'subscription_expires_at' => 'datetime',
             'email_verified_at'       => 'datetime',
         ];
+    }
+
+    public function favorites(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            WorldHeritage::class,
+            'user_favorite',
+            'user_id',
+            'world_heritage_site_id'
+        );
     }
 }

--- a/src/app/Packages/Domains/Favorite/FavoriteRepository.php
+++ b/src/app/Packages/Domains/Favorite/FavoriteRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Packages\Domains\Favorite;
+
+use App\Models\User;
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+use Exception;
+
+class FavoriteRepository implements FavoriteRepositoryInterface
+{
+    public function __construct(
+        private User $userModel
+    ) {}
+
+    public function addFavorite(int $userId, int $worldHeritageSiteId): void
+    {
+        $user = $this->userModel->find($userId);
+
+        if ($user === null) {
+            throw new Exception('User not found.');
+        }
+
+        $user->favorites()->attach($worldHeritageSiteId);
+    }
+}

--- a/src/app/Packages/Domains/Favorite/Interface/FavoriteRepositoryInterface.php
+++ b/src/app/Packages/Domains/Favorite/Interface/FavoriteRepositoryInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Packages\Domains\Favorite\Interface;
+
+interface FavoriteRepositoryInterface
+{
+    public function addFavorite(int $userId, int $worldHeritageSiteId): void;
+}

--- a/src/app/Packages/Domains/Favorite/Tests/FavoriteRepositoryTest.php
+++ b/src/app/Packages/Domains/Favorite/Tests/FavoriteRepositoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Packages\Domains\Favorite\Tests;
+
+use App\Models\User;
+use App\Models\WorldHeritage;
+use App\Packages\Domains\Favorite\FavoriteRepository;
+use Exception;
+use Faker\Factory as FakerFactory;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class FavoriteRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            DB::connection('mysql')->table('user_favorite')->truncate();
+            WorldHeritage::truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function repository(): FavoriteRepository
+    {
+        return new FavoriteRepository(new User());
+    }
+
+    private function seedUser(): User
+    {
+        $faker = FakerFactory::create();
+
+        return User::create([
+            'first_name'              => $faker->firstName(),
+            'last_name'               => $faker->lastName(),
+            'email'                   => $faker->unique()->safeEmail(),
+            'password'                => bcrypt('password'),
+            'age_range'               => 'teens',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+    }
+
+    private function seedWorldHeritage(int $id): WorldHeritage
+    {
+        return WorldHeritage::create([
+            'id'             => $id,
+            'official_name'  => 'Example Site',
+            'name'           => 'Example Site',
+            'region'         => 'Asia',
+            'category'       => 'Cultural',
+            'criteria'       => ['i'],
+            'year_inscribed' => 2000,
+        ]);
+    }
+
+    public function test_addFavorite_attaches_world_heritage_site_to_user(): void
+    {
+        $user          = $this->seedUser();
+        $worldHeritage = $this->seedWorldHeritage(1);
+
+        $this->repository()->addFavorite($user->id, $worldHeritage->id);
+
+        $this->assertDatabaseHas('user_favorite', [
+            'user_id'                => $user->id,
+            'world_heritage_site_id' => $worldHeritage->id,
+        ]);
+    }
+
+    public function test_addFavorite_throws_exception_when_user_not_found(): void
+    {
+        $worldHeritage = $this->seedWorldHeritage(1);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->repository()->addFavorite(999999, $worldHeritage->id);
+    }
+}

--- a/src/app/Providers/RepositoryProvider.php
+++ b/src/app/Providers/RepositoryProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Packages\Domains\Favorite\FavoriteRepository;
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
 use App\Packages\Domains\User\Interface\UserRepositroyInterface;
 use App\Packages\Domains\User\UserRepository;
 use App\Packages\Domains\WorldHeritageRepository;
@@ -20,6 +22,11 @@ class RepositoryProvider extends ServiceProvider
         $this->app->bind(
             UserRepositroyInterface::class,
             UserRepository::class
+        );
+
+        $this->app->bind(
+            FavoriteRepositoryInterface::class,
+            FavoriteRepository::class
         );
     }
 


### PR DESCRIPTION
## Motivation

Following the domain-layer migration for the `user_favorite` join table (#560), this PR implements the Infra layer for the favorites feature: a `FavoriteRepositoryInterface` and its Eloquent-backed `FavoriteRepository` implementation, allowing a user to add a world heritage site to their favorites.

## What I have done

- Added a `User::favorites()` BelongsToMany relation to `WorldHeritage` via the `user_favorite` pivot table
- Added `FavoriteRepositoryInterface` with `addFavorite(int $userId, int $worldHeritageSiteId): void`
- Added `FavoriteRepository`, implementing the interface via `$user->favorites()->attach()`, throwing an exception when the user is not found
- Bound `FavoriteRepositoryInterface` to `FavoriteRepository` in `RepositoryProvider`
- Added an integration test for `FavoriteRepository` against the real test database

## Test Results

- test_addFavorite_attaches_world_heritage_site_to_user
- test_addFavorite_throws_exception_when_user_not_found