### PR TITLE
feat: implement Application layer for adding favorites / お気に入り追加のApplication層実装

### DIFF
--- a/src/app/Packages/Features/CommandUseCases/UseCase/Favorite/AddFavoriteUseCase.php
+++ b/src/app/Packages/Features/CommandUseCases/UseCase/Favorite/AddFavoriteUseCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Packages\Features\CommandUseCases\UseCase\Favorite;
+
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+
+final class AddFavoriteUseCase
+{
+    public function __construct(
+        private readonly FavoriteRepositoryInterface $favoriteRepository,
+    ) {}
+
+    public function handle(int $userId, int $worldHeritageSiteId): void
+    {
+        $this->favoriteRepository->addFavorite($userId, $worldHeritageSiteId);
+    }
+}

--- a/src/app/Packages/Features/Tests/CommandUseCases/AddFavoriteUseCaseTest.php
+++ b/src/app/Packages/Features/Tests/CommandUseCases/AddFavoriteUseCaseTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Packages\Features\Tests\CommandUseCases;
+
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+use App\Packages\Features\CommandUseCases\UseCase\Favorite\AddFavoriteUseCase;
+use Exception;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class AddFavoriteUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    #[\PHPUnit\Framework\Attributes\DoesNotPerformAssertions]
+    public function test_handle_calls_repository_addFavorite_with_given_ids(): void
+    {
+        /** @var FavoriteRepositoryInterface|MockInterface $repository */
+        $repository = Mockery::mock(FavoriteRepositoryInterface::class);
+        $repository->shouldReceive('addFavorite')
+            ->once()
+            ->with(1, 2);
+
+        (new AddFavoriteUseCase($repository))->handle(1, 2);
+    }
+
+    public function test_handle_propagates_exception_when_user_not_found(): void
+    {
+        /** @var FavoriteRepositoryInterface|MockInterface $repository */
+        $repository = Mockery::mock(FavoriteRepositoryInterface::class);
+        $repository->shouldReceive('addFavorite')
+            ->once()
+            ->with(999999, 2)
+            ->andThrow(new Exception('User not found.'));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        (new AddFavoriteUseCase($repository))->handle(999999, 2);
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Following the Infra layer (#561), this PR implements the Application layer for the favorites feature: an `AddFavoriteUseCase` that lets a user add a world heritage site to their favorites via `FavoriteRepositoryInterface`.

No `UseCommand` or `Dto` is introduced here — `handle()` only needs `user_id` and `world_heritage_id`, and the operation returns `void`, so passing primitives directly follows the existing `DeleteUserUseCase` pattern rather than adding an object wrapper for two scalar values.

## What I have done / 実施内容

- Added `AddFavoriteUseCase::handle(int $userId, int $worldHeritageSiteId): void`, delegating to `FavoriteRepositoryInterface::addFavorite()`
- Added a unit test for `AddFavoriteUseCase` using Mockery

## Test Results / テスト結果

- test_handle_calls_repository_addFavorite_with_given_ids
- test_handle_propagates_exception_when_user_not_found