### PR TITLE
feat: implement Presentation layer for POST /api/v1/favorites / お気に入り追加のPresentation層実装

### DIFF
--- a/src/app/Packages/Features/Controller/FavoriteController.php
+++ b/src/app/Packages/Features/Controller/FavoriteController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Packages\Features\Controller;
+
+use App\Http\Controllers\Controller;
+use App\Packages\Features\CommandUseCases\UseCase\Favorite\AddFavoriteUseCase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class FavoriteController extends Controller
+{
+    public function addFavorite(
+        Request $request,
+        AddFavoriteUseCase $useCase,
+    ): JsonResponse {
+        try {
+            $useCase->handle(
+                $request->user()->id,
+                (int) $request->input('world_heritage_id'),
+            );
+
+            return response()->json([
+                'status' => 'success',
+            ], 201);
+        } catch (Throwable $throwable) {
+            if ($throwable->getMessage() === 'User not found.') {
+                return response()->json([
+                    'status'  => 'error',
+                    'message' => 'User not found.',
+                ], 404);
+            }
+
+            Log::error('Failed to add favorite', [
+                'message' => $throwable->getMessage(),
+                'trace'   => $throwable->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ], 500);
+        }
+    }
+}

--- a/src/app/Packages/Features/Tests/FavoriteControllerTest.php
+++ b/src/app/Packages/Features/Tests/FavoriteControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Packages\Features\Tests;
+
+use App\Models\User;
+use App\Models\WorldHeritage;
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+use App\Packages\Features\CommandUseCases\UseCase\Favorite\AddFavoriteUseCase;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class FavoriteControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->truncate();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncate();
+        parent::tearDown();
+    }
+
+    private function truncate(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            DB::connection('mysql')->table('user_favorite')->truncate();
+            DB::connection('mysql')->table('personal_access_tokens')->truncate();
+            WorldHeritage::truncate();
+            User::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    private function seedUser(): User
+    {
+        return User::create([
+            'first_name'              => 'John',
+            'last_name'               => 'Doe',
+            'email'                   => 'john@example.com',
+            'password'                => bcrypt('secret123'),
+            'age_range'               => '20s',
+            'subscription_tier'       => 'free',
+            'subscription_expires_at' => null,
+        ]);
+    }
+
+    private function seedWorldHeritage(int $id): WorldHeritage
+    {
+        return WorldHeritage::create([
+            'id'             => $id,
+            'official_name'  => 'Example Site',
+            'name'           => 'Example Site',
+            'region'         => 'Asia',
+            'category'       => 'Cultural',
+            'criteria'       => ['i'],
+            'year_inscribed' => 2000,
+        ]);
+    }
+
+    public function test_addFavorite_returns_201_and_persists_favorite_when_authenticated(): void
+    {
+        $user          = $this->seedUser();
+        $worldHeritage = $this->seedWorldHeritage(1);
+        $token         = $user->createToken('auth-token')->plainTextToken;
+
+        $response = $this->withToken($token)
+            ->postJson('/api/v1/favorites', ['world_heritage_id' => $worldHeritage->id]);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment(['status' => 'success']);
+
+        $this->assertDatabaseHas('user_favorite', [
+            'user_id'                => $user->id,
+            'world_heritage_site_id' => $worldHeritage->id,
+        ]);
+    }
+
+    public function test_addFavorite_returns_401_when_unauthenticated(): void
+    {
+        $worldHeritage = $this->seedWorldHeritage(1);
+
+        $response = $this->postJson('/api/v1/favorites', ['world_heritage_id' => $worldHeritage->id]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_addFavorite_returns_500_on_unexpected_error(): void
+    {
+        $user  = $this->seedUser();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        $repository = Mockery::mock(FavoriteRepositoryInterface::class);
+        $repository->shouldReceive('addFavorite')
+            ->andThrow(new RuntimeException('Unexpected error'));
+
+        $this->app->instance(AddFavoriteUseCase::class, new AddFavoriteUseCase($repository));
+
+        $response = $this->withToken($token)
+            ->postJson('/api/v1/favorites', ['world_heritage_id' => 1]);
+
+        $response->assertStatus(500)
+            ->assertJsonFragment([
+                'status'  => 'error',
+                'message' => 'Internal Server Error',
+            ]);
+    }
+}

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Packages\Features\Controller\AuthController;
+use App\Packages\Features\Controller\FavoriteController;
 use App\Packages\Features\Controller\UserController;
 use App\Packages\Features\Controller\WorldHeritageController;
 use Illuminate\Support\Facades\Route;
@@ -25,5 +26,9 @@ Route::prefix('v1')->group(function (): void {
         Route::get('/{id}', 'getUserById');
         Route::patch('/{id}', 'updateUser');
         Route::delete('/{id}', 'deleteUser');
+    });
+
+    Route::controller(FavoriteController::class)->prefix('favorites')->middleware('auth:sanctum')->group(function (): void {
+        Route::post('/', 'addFavorite');
     });
 });


### PR DESCRIPTION
## Motivation / 目的

Following the Application layer (#562), this PR implements the Presentation layer for the favorites feature: a `FavoriteController` exposing `POST /api/v1/favorites`, so an authenticated user can add a world heritage site to their favorites.

The user id is resolved from the authenticated request (`$request->user()->id`), not from the request body, following the same pattern as `AuthController::me()` — this prevents a client from adding favorites on behalf of another user.

## What I have done / 実施内容

- Added `FavoriteController::addFavorite`, calling `AddFavoriteUseCase` with the authenticated user id and `world_heritage_id` from the request body
- Registered `POST /api/v1/favorites` behind `auth:sanctum` middleware
- Added an integration test covering 201 (success + DB persistence), 401 (unauthenticated), and 500 (unexpected error)

## Test Results / テスト結果

- test_addFavorite_returns_201_and_persists_favorite_when_authenticated
- test_addFavorite_returns_401_when_unauthenticated
- test_addFavorite_returns_500_on_unexpected_error

Full suite: 188 passed.