### PR TITLE
feat: implement Infra layer for favorite heritages list API / お気に入り一覧APIのInfra層実装

### DIFF
--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -42,6 +42,6 @@ class User extends Authenticatable
             'user_favorite',
             'user_id',
             'world_heritage_site_id'
-        );
+        )->withTimestamps();
     }
 }

--- a/src/app/Packages/Domains/Favorite/FavoriteRepository.php
+++ b/src/app/Packages/Domains/Favorite/FavoriteRepository.php
@@ -22,4 +22,18 @@ class FavoriteRepository implements FavoriteRepositoryInterface
 
         $user->favorites()->attach($worldHeritageSiteId);
     }
+
+    public function getFavoriteWorldHeritageIds(int $userId): array
+    {
+        $user = $this->userModel->find($userId);
+
+        if ($user === null) {
+            throw new Exception('User not found.');
+        }
+
+        return $user->favorites()
+            ->orderBy('user_favorite.created_at', 'desc')
+            ->pluck('world_heritage_sites.id')
+            ->all();
+    }
 }

--- a/src/app/Packages/Domains/Favorite/Interface/FavoriteRepositoryInterface.php
+++ b/src/app/Packages/Domains/Favorite/Interface/FavoriteRepositoryInterface.php
@@ -5,4 +5,6 @@ namespace App\Packages\Domains\Favorite\Interface;
 interface FavoriteRepositoryInterface
 {
     public function addFavorite(int $userId, int $worldHeritageSiteId): void;
+
+    public function getFavoriteWorldHeritageIds(int $userId): array;
 }

--- a/src/app/Packages/Domains/Favorite/Tests/FavoriteRepositoryTest.php
+++ b/src/app/Packages/Domains/Favorite/Tests/FavoriteRepositoryTest.php
@@ -90,4 +90,35 @@ class FavoriteRepositoryTest extends TestCase
 
         $this->repository()->addFavorite(999999, $worldHeritage->id);
     }
+
+    public function test_getFavoriteWorldHeritageIds_returns_ids_ordered_by_most_recently_favorited(): void
+    {
+        $user           = $this->seedUser();
+        $worldHeritage1 = $this->seedWorldHeritage(1);
+        $worldHeritage2 = $this->seedWorldHeritage(2);
+
+        $user->favorites()->attach($worldHeritage1->id, ['created_at' => now()->subMinute()]);
+        $user->favorites()->attach($worldHeritage2->id, ['created_at' => now()]);
+
+        $result = $this->repository()->getFavoriteWorldHeritageIds($user->id);
+
+        $this->assertSame([$worldHeritage2->id, $worldHeritage1->id], $result);
+    }
+
+    public function test_getFavoriteWorldHeritageIds_returns_empty_array_when_no_favorites(): void
+    {
+        $user = $this->seedUser();
+
+        $result = $this->repository()->getFavoriteWorldHeritageIds($user->id);
+
+        $this->assertSame([], $result);
+    }
+
+    public function test_getFavoriteWorldHeritageIds_throws_exception_when_user_not_found(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('User not found.');
+
+        $this->repository()->getFavoriteWorldHeritageIds(999999);
+    }
 }


### PR DESCRIPTION
## Motivation / 目的

Add the Infra layer support needed for a "list my favorite heritages" API: a way to fetch the world heritage site ids a user has favorited, reusing the existing `favorites()` relation added for `addFavorite()`.

## What I have done / 実施内容

- Added `FavoriteRepositoryInterface::getFavoriteWorldHeritageIds(int $userId): array`
- Implemented it in `FavoriteRepository`, returning world heritage site ids ordered by most recently favorited first, throwing `Exception('User not found.')` when the user doesn't exist (same convention as `addFavorite`)
- Added `withTimestamps()` to `User::favorites()` so pivot `created_at` is populated on `attach()`, which the new method orders by
- Added integration tests against the real test database

## Test Results / テスト結果

- test_getFavoriteWorldHeritageIds_returns_ids_ordered_by_most_recently_favorited
- test_getFavoriteWorldHeritageIds_returns_empty_array_when_no_favorites
- test_getFavoriteWorldHeritageIds_throws_exception_when_user_not_found

Closes #566