### PR TITLE
feat: implement Infra layer for favorite heritages list (WorldHeritageQueryService) / お気に入り一覧のInfra層実装（WorldHeritageQueryService）

### DIFF
--- a/src/app/Packages/Domains/WorldHeritage/Tests/QueryService/WorldHeritageQueryService_getHeritagesByIdsTest.php
+++ b/src/app/Packages/Domains/WorldHeritage/Tests/QueryService/WorldHeritageQueryService_getHeritagesByIdsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Packages\Domains\WorldHeritage\Tests\QueryService;
+
+use App\Models\Country;
+use App\Models\Image;
+use App\Models\WorldHeritage;
+use App\Models\WorldHeritageDescription;
+use App\Packages\Domains\WorldHeritage\WorldHeritageQueryService;
+use App\Packages\Domains\WorldHeritage\Ports\WorldHeritageSearchPort;
+use App\Packages\Domains\WorldHeritage\Ports\Dto\HeritageSearchResult;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class WorldHeritageQueryService_getHeritagesByIdsTest extends TestCase
+{
+    private WorldHeritageQueryService $queryService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+
+        $seeder = new DatabaseSeeder();
+        $seeder->run();
+
+        $this->app->bind(WorldHeritageSearchPort::class, static function () {
+            return new class implements WorldHeritageSearchPort {
+                public function search($query, int $currentPage, int $perPage): HeritageSearchResult {
+                    return new HeritageSearchResult(ids: [], total: 0, currentPage: 1, perPage: $perPage, lastPage: 0);
+                }
+            };
+        });
+
+        $this->queryService = app(WorldHeritageQueryService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            WorldHeritage::truncate();
+            Country::truncate();
+            DB::table('site_state_parties')->truncate();
+            Image::truncate();
+            WorldHeritageDescription::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    public function test_returns_world_heritage_dto_collection(): void
+    {
+        $ids = DB::table('world_heritage_sites')->orderBy('id')->limit(2)->pluck('id')->all();
+
+        $result = $this->queryService->getHeritagesByIds($ids);
+
+        $this->assertInstanceOf(WorldHeritageDtoCollection::class, $result);
+    }
+
+    public function test_preserves_order_of_given_ids(): void
+    {
+        $ids = DB::table('world_heritage_sites')->orderBy('id')->limit(3)->pluck('id')->all();
+        $this->assertCount(3, $ids, 'Seeder must insert at least 3 world heritages.');
+
+        $requested = [$ids[2], $ids[0], $ids[1]];
+
+        $result = $this->queryService->getHeritagesByIds($requested);
+
+        $resultIds = array_map(fn ($dto) => $dto->getId(), $result->getHeritages());
+        $this->assertSame($requested, $resultIds);
+    }
+
+    public function test_returns_empty_collection_when_no_ids_given(): void
+    {
+        $result = $this->queryService->getHeritagesByIds([]);
+
+        $this->assertSame([], $result->getHeritages());
+    }
+
+    public function test_skips_missing_ids_without_failing(): void
+    {
+        $existingId = (int) DB::table('world_heritage_sites')->orderBy('id')->value('id');
+        $this->assertNotNull($existingId, 'Seeder must insert at least 1 world heritage.');
+
+        $result = $this->queryService->getHeritagesByIds([$existingId, 999_999_999]);
+
+        $resultIds = array_map(fn ($dto) => $dto->getId(), $result->getHeritages());
+        $this->assertSame([$existingId], $resultIds);
+    }
+}

--- a/src/app/Packages/Domains/WorldHeritage/WorldHeritageQueryService.php
+++ b/src/app/Packages/Domains/WorldHeritage/WorldHeritageQueryService.php
@@ -246,6 +246,17 @@ class WorldHeritageQueryService implements WorldHeritageQueryServiceInterface
         );
     }
 
+    public function getHeritagesByIds(array $ids): WorldHeritageDtoCollection
+    {
+        $models = $this->readQueryService->findByIdsPreserveOrder($ids);
+
+        $payloads = $models
+            ->map(fn ($m) => $this->buildWorldHeritagePayload($m))
+            ->all();
+
+        return $this->buildDtoFromCollection($payloads);
+    }
+
     public function getEachRegionsHeritagesCount(): array
     {
         $counts = $this->model

--- a/src/app/Packages/Features/QueryUseCases/QueryServiceInterface/WorldHeritageQueryServiceInterface.php
+++ b/src/app/Packages/Features/QueryUseCases/QueryServiceInterface/WorldHeritageQueryServiceInterface.php
@@ -5,6 +5,7 @@ namespace App\Packages\Features\QueryUseCases\QueryServiceInterface;
 use App\Common\Pagination\PaginationDto;
 
 use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDto;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
 
 use App\Packages\Features\QueryUseCases\ListQuery\AlgoliaSearchListQuery;
 
@@ -24,6 +25,10 @@ interface WorldHeritageQueryServiceInterface
     public function searchHeritages(
         AlgoliaSearchListQuery $query
     ): PaginationDto;
+
+    public function getHeritagesByIds(
+        array $ids
+    ): WorldHeritageDtoCollection;
 
     public function getEachRegionsHeritagesCount(): array;
 }


### PR DESCRIPTION
## Motivation / 目的

Following #564 (`FavoriteRepository::getFavoriteWorldHeritageIds`), add the remaining Infra-level piece needed for the favorites list: given a list of world heritage ids, return them as a `WorldHeritageDtoCollection` so the Application layer doesn't need to duplicate the existing payload-building logic (`buildWorldHeritagePayload` + `WorldHeritageDtoCollectionFactory`) already used by `getAllHeritages()` / `searchHeritages()`.

Pagination is intentionally out of scope here — it will be added later once needed; `getHeritagesByIds()` just returns the full collection for the ids it's given.

## What I have done / 実施内容

- Added `WorldHeritageQueryServiceInterface::getHeritagesByIds(array $ids): WorldHeritageDtoCollection`
- Implemented it in `WorldHeritageQueryService`, reusing the same `findByIdsPreserveOrder()` + `buildWorldHeritagePayload()` + `buildDtoFromCollection()` pipeline as `searchHeritages()`
- Added integration tests against the real test database (seeded via `DatabaseSeeder`)

## Test Results / テスト結果

- test_returns_world_heritage_dto_collection
- test_preserves_order_of_given_ids
- test_returns_empty_collection_when_no_ids_given
- test_skips_missing_ids_without_failing

Full suite: 197 passed.