### PR TITLE
feat: implement Infra and Application layers for favorite heritages list / お気に入り一覧のInfra・Application層実装

### DIFF
--- a/src/app/Packages/Domains/WorldHeritage/Tests/QueryService/WorldHeritageQueryService_getHeritagesByIdsTest.php
+++ b/src/app/Packages/Domains/WorldHeritage/Tests/QueryService/WorldHeritageQueryService_getHeritagesByIdsTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Packages\Domains\WorldHeritage\Tests\QueryService;
+
+use App\Models\Country;
+use App\Models\Image;
+use App\Models\WorldHeritage;
+use App\Models\WorldHeritageDescription;
+use App\Packages\Domains\WorldHeritage\WorldHeritageQueryService;
+use App\Packages\Domains\WorldHeritage\Ports\WorldHeritageSearchPort;
+use App\Packages\Domains\WorldHeritage\Ports\Dto\HeritageSearchResult;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class WorldHeritageQueryService_getHeritagesByIdsTest extends TestCase
+{
+    private WorldHeritageQueryService $queryService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->refresh();
+
+        $seeder = new DatabaseSeeder();
+        $seeder->run();
+
+        $this->app->bind(WorldHeritageSearchPort::class, static function () {
+            return new class implements WorldHeritageSearchPort {
+                public function search($query, int $currentPage, int $perPage): HeritageSearchResult {
+                    return new HeritageSearchResult(ids: [], total: 0, currentPage: 1, perPage: $perPage, lastPage: 0);
+                }
+            };
+        });
+
+        $this->queryService = app(WorldHeritageQueryService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->refresh();
+        parent::tearDown();
+    }
+
+    private function refresh(): void
+    {
+        if (env('APP_ENV') === 'testing') {
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=0;');
+            WorldHeritage::truncate();
+            Country::truncate();
+            DB::table('site_state_parties')->truncate();
+            Image::truncate();
+            WorldHeritageDescription::truncate();
+            DB::connection('mysql')->statement('SET FOREIGN_KEY_CHECKS=1;');
+        }
+    }
+
+    public function test_returns_world_heritage_dto_collection(): void
+    {
+        $ids = DB::table('world_heritage_sites')->orderBy('id')->limit(2)->pluck('id')->all();
+
+        $result = $this->queryService->getHeritagesByIds($ids);
+
+        $this->assertInstanceOf(WorldHeritageDtoCollection::class, $result);
+    }
+
+    public function test_preserves_order_of_given_ids(): void
+    {
+        $ids = DB::table('world_heritage_sites')->orderBy('id')->limit(3)->pluck('id')->all();
+        $this->assertCount(3, $ids, 'Seeder must insert at least 3 world heritages.');
+
+        $requested = [$ids[2], $ids[0], $ids[1]];
+
+        $result = $this->queryService->getHeritagesByIds($requested);
+
+        $resultIds = array_map(fn ($dto) => $dto->getId(), $result->getHeritages());
+        $this->assertSame($requested, $resultIds);
+    }
+
+    public function test_returns_empty_collection_when_no_ids_given(): void
+    {
+        $result = $this->queryService->getHeritagesByIds([]);
+
+        $this->assertSame([], $result->getHeritages());
+    }
+
+    public function test_skips_missing_ids_without_failing(): void
+    {
+        $existingId = (int) DB::table('world_heritage_sites')->orderBy('id')->value('id');
+        $this->assertNotNull($existingId, 'Seeder must insert at least 1 world heritage.');
+
+        $result = $this->queryService->getHeritagesByIds([$existingId, 999_999_999]);
+
+        $resultIds = array_map(fn ($dto) => $dto->getId(), $result->getHeritages());
+        $this->assertSame([$existingId], $resultIds);
+    }
+}

--- a/src/app/Packages/Domains/WorldHeritage/WorldHeritageQueryService.php
+++ b/src/app/Packages/Domains/WorldHeritage/WorldHeritageQueryService.php
@@ -246,6 +246,17 @@ class WorldHeritageQueryService implements WorldHeritageQueryServiceInterface
         );
     }
 
+    public function getHeritagesByIds(array $ids): WorldHeritageDtoCollection
+    {
+        $models = $this->readQueryService->findByIdsPreserveOrder($ids);
+
+        $payloads = $models
+            ->map(fn ($m) => $this->buildWorldHeritagePayload($m))
+            ->all();
+
+        return $this->buildDtoFromCollection($payloads);
+    }
+
     public function getEachRegionsHeritagesCount(): array
     {
         $counts = $this->model

--- a/src/app/Packages/Features/QueryUseCases/QueryServiceInterface/WorldHeritageQueryServiceInterface.php
+++ b/src/app/Packages/Features/QueryUseCases/QueryServiceInterface/WorldHeritageQueryServiceInterface.php
@@ -5,6 +5,7 @@ namespace App\Packages\Features\QueryUseCases\QueryServiceInterface;
 use App\Common\Pagination\PaginationDto;
 
 use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDto;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
 
 use App\Packages\Features\QueryUseCases\ListQuery\AlgoliaSearchListQuery;
 
@@ -24,6 +25,10 @@ interface WorldHeritageQueryServiceInterface
     public function searchHeritages(
         AlgoliaSearchListQuery $query
     ): PaginationDto;
+
+    public function getHeritagesByIds(
+        array $ids
+    ): WorldHeritageDtoCollection;
 
     public function getEachRegionsHeritagesCount(): array;
 }

--- a/src/app/Packages/Features/QueryUseCases/Tests/UseCase/GetFavoriteHeritagesUseCaseTest.php
+++ b/src/app/Packages/Features/QueryUseCases/Tests/UseCase/GetFavoriteHeritagesUseCaseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Packages\Features\QueryUseCases\Tests\UseCase;
+
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
+use App\Packages\Features\QueryUseCases\QueryServiceInterface\WorldHeritageQueryServiceInterface;
+use App\Packages\Features\QueryUseCases\UseCase\Favorite\GetFavoriteHeritagesUseCase;
+use Mockery;
+use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
+
+class GetFavoriteHeritagesUseCaseTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_handle_returns_world_heritage_dto_collection_for_favorite_ids(): void
+    {
+        /** @var FavoriteRepositoryInterface|MockInterface $favoriteRepository */
+        $favoriteRepository = Mockery::mock(FavoriteRepositoryInterface::class);
+        $favoriteRepository->shouldReceive('getFavoriteWorldHeritageIds')
+            ->once()
+            ->with(1)
+            ->andReturn([3, 2]);
+
+        $dtoCollection = new WorldHeritageDtoCollection();
+
+        /** @var WorldHeritageQueryServiceInterface|MockInterface $worldHeritageQueryService */
+        $worldHeritageQueryService = Mockery::mock(WorldHeritageQueryServiceInterface::class);
+        $worldHeritageQueryService->shouldReceive('getHeritagesByIds')
+            ->once()
+            ->with([3, 2])
+            ->andReturn($dtoCollection);
+
+        $useCase = new GetFavoriteHeritagesUseCase($favoriteRepository, $worldHeritageQueryService);
+
+        $result = $useCase->handle(1);
+
+        $this->assertSame($dtoCollection, $result);
+    }
+
+    public function test_handle_returns_empty_collection_when_user_has_no_favorites(): void
+    {
+        /** @var FavoriteRepositoryInterface|MockInterface $favoriteRepository */
+        $favoriteRepository = Mockery::mock(FavoriteRepositoryInterface::class);
+        $favoriteRepository->shouldReceive('getFavoriteWorldHeritageIds')
+            ->once()
+            ->with(1)
+            ->andReturn([]);
+
+        $dtoCollection = new WorldHeritageDtoCollection();
+
+        /** @var WorldHeritageQueryServiceInterface|MockInterface $worldHeritageQueryService */
+        $worldHeritageQueryService = Mockery::mock(WorldHeritageQueryServiceInterface::class);
+        $worldHeritageQueryService->shouldReceive('getHeritagesByIds')
+            ->once()
+            ->with([])
+            ->andReturn($dtoCollection);
+
+        $useCase = new GetFavoriteHeritagesUseCase($favoriteRepository, $worldHeritageQueryService);
+
+        $result = $useCase->handle(1);
+
+        $this->assertSame([], $result->getHeritages());
+    }
+}

--- a/src/app/Packages/Features/QueryUseCases/UseCase/Favorite/GetFavoriteHeritagesUseCase.php
+++ b/src/app/Packages/Features/QueryUseCases/UseCase/Favorite/GetFavoriteHeritagesUseCase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Packages\Features\QueryUseCases\UseCase\Favorite;
+
+use App\Packages\Domains\Favorite\Interface\FavoriteRepositoryInterface;
+use App\Packages\Features\QueryUseCases\Dto\WorldHeritageDtoCollection;
+use App\Packages\Features\QueryUseCases\QueryServiceInterface\WorldHeritageQueryServiceInterface;
+
+final class GetFavoriteHeritagesUseCase
+{
+    public function __construct(
+        private readonly FavoriteRepositoryInterface $favoriteRepository,
+        private readonly WorldHeritageQueryServiceInterface $worldHeritageQueryService,
+    ) {}
+
+    public function handle(int $userId): WorldHeritageDtoCollection
+    {
+        $ids = $this->favoriteRepository->getFavoriteWorldHeritageIds($userId);
+
+        return $this->worldHeritageQueryService->getHeritagesByIds($ids);
+    }
+}


### PR DESCRIPTION
## Motivation / 目的

Continue the favorite heritages list feature. This PR adds the pieces needed to turn a user's favorite ids into a displayable list of world heritages:

- Infra: `WorldHeritageQueryService::getHeritagesByIds()`, reusing the existing `findByIdsPreserveOrder()` + payload/DTO pipeline already used by `searchHeritages()`.
- Application: `GetFavoriteHeritagesUseCase`, which combines `FavoriteRepository::getFavoriteWorldHeritageIds()` with `getHeritagesByIds()` to return a `WorldHeritageDtoCollection` for a given user.

Pagination is intentionally out of scope — it will be added later once needed.

## What I have done / 実施内容

- Added `WorldHeritageQueryServiceInterface::getHeritagesByIds(array $ids): WorldHeritageDtoCollection`
- Implemented it in `WorldHeritageQueryService`
- Added `GetFavoriteHeritagesUseCase::handle(int $userId): WorldHeritageDtoCollection`

## Test Results / テスト結果

- test_returns_world_heritage_dto_collection
- test_preserves_order_of_given_ids
- test_returns_empty_collection_when_no_ids_given
- test_skips_missing_ids_without_failing
- test_handle_returns_world_heritage_dto_collection_for_favorite_ids
- test_handle_returns_empty_collection_when_user_has_no_favorites
